### PR TITLE
Formatting and semantic updates

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -23,7 +23,7 @@
 			}
 		},
 		{
-			"files": ["*.js", "*.ts", "*.json"],
+			"files": ["*.json"],
 			"options": {
 				"useTabs": true
 			}

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,7 +1,7 @@
 module.exports = {
-	skipFiles: ['/vendor', '/test'],
-	mocha: {
-		grep: '@skip-on-coverage', // Find everything with this tag
-		invert: true, // Run the grep's inverse set.
-	},
+    skipFiles: ['/vendor', '/test'],
+    mocha: {
+        grep: '@skip-on-coverage', // Find everything with this tag
+        invert: true, // Run the grep's inverse set.
+    },
 };

--- a/contracts/messaging/FuelMessagesEnabled.sol
+++ b/contracts/messaging/FuelMessagesEnabled.sol
@@ -11,7 +11,7 @@ abstract contract FuelMessagesEnabled {
     /////////////
 
     /// @notice IFuelMessagePortal contract used to send and receive messages from Fuel
-    IFuelMessagePortal public s_fuelMessagePortal;
+    IFuelMessagePortal internal _fuelMessagePortal;
 
     ////////////////////////
     // Function Modifiers //
@@ -19,16 +19,26 @@ abstract contract FuelMessagesEnabled {
 
     /// @notice Enforces that the modified function is only callable by the Fuel message portal
     modifier onlyFromPortal() {
-        require(msg.sender == address(s_fuelMessagePortal), "Caller is not the portal");
+        require(msg.sender == address(_fuelMessagePortal), "Caller is not the portal");
         _;
     }
 
     /// @notice Enforces that the modified function is only callable by the portal and a specific Fuel account
     /// @param fuelSender The only sender on Fuel which is authenticated to call this function
     modifier onlyFromFuelSender(bytes32 fuelSender) {
-        require(msg.sender == address(s_fuelMessagePortal), "Caller is not the portal");
-        require(s_fuelMessagePortal.getMessageSender() == fuelSender, "Invalid message sender");
+        require(msg.sender == address(_fuelMessagePortal), "Caller is not the portal");
+        require(_fuelMessagePortal.messageSender() == fuelSender, "Invalid message sender");
         _;
+    }
+
+    //////////////////////
+    // Public Functions //
+    //////////////////////
+
+    /// @notice Gets the currently set PoA key
+    /// @return fuelMessagePortal Fuel message portal address
+    function fuelMessagePortal() public view returns (address) {
+        return address(_fuelMessagePortal);
     }
 
     ////////////////////////
@@ -39,7 +49,7 @@ abstract contract FuelMessagesEnabled {
     /// @param recipient The message receiver address or predicate root
     /// @param data The message data to be sent to the receiver
     function sendMessage(bytes32 recipient, bytes memory data) internal {
-        s_fuelMessagePortal.sendMessage(recipient, data);
+        _fuelMessagePortal.sendMessage(recipient, data);
     }
 
     /// @notice Send a message to a recipient on Fuel
@@ -47,11 +57,11 @@ abstract contract FuelMessagesEnabled {
     /// @param amount The amount of ETH to send with message
     /// @param data The message data to be sent to the receiver
     function sendMessage(bytes32 recipient, uint256 amount, bytes memory data) internal {
-        s_fuelMessagePortal.sendMessage{value: amount}(recipient, data);
+        _fuelMessagePortal.sendMessage{value: amount}(recipient, data);
     }
 
     /// @notice Used by message receiving contracts to get the address on Fuel that sent the message
-    function getMessageSender() internal view returns (bytes32) {
-        return s_fuelMessagePortal.getMessageSender();
+    function messageSender() internal view returns (bytes32) {
+        return _fuelMessagePortal.messageSender();
     }
 }

--- a/contracts/messaging/FuelMessagesEnabledUpgradeable.sol
+++ b/contracts/messaging/FuelMessagesEnabledUpgradeable.sol
@@ -20,7 +20,7 @@ abstract contract FuelMessagesEnabledUpgradeable is Initializable, FuelMessagesE
 
     // solhint-disable-next-line func-name-mixedcase
     function __FuelMessagesEnabled_init_unchained(IFuelMessagePortal fuelMessagePortal) internal onlyInitializing {
-        s_fuelMessagePortal = fuelMessagePortal;
+        _fuelMessagePortal = fuelMessagePortal;
     }
 
     /**

--- a/contracts/messaging/IFuelMessagePortal.sol
+++ b/contracts/messaging/IFuelMessagePortal.sol
@@ -28,12 +28,12 @@ interface IFuelMessagePortal {
 
     /// @notice Send only ETH to the given recipient
     /// @param recipient The recipient address
-    function sendETH(bytes32 recipient) external payable;
+    function depositETH(bytes32 recipient) external payable;
 
     ///////////////////////////////
     // Public Functions Incoming //
     ///////////////////////////////
 
     /// @notice Used by message receiving contracts to get the address on Fuel that sent the message
-    function getMessageSender() external view returns (bytes32);
+    function messageSender() external view returns (bytes32);
 }

--- a/contracts/sidechain/FuelSidechainConsensus.sol
+++ b/contracts/sidechain/FuelSidechainConsensus.sol
@@ -14,7 +14,7 @@ contract FuelSidechainConsensus is Initializable, OwnableUpgradeable, PausableUp
     /////////////
 
     /// @dev The Current PoA key
-    address public s_authorityKey;
+    address private _authorityKey;
 
     /////////////////////////////
     // Constructor/Initializer //
@@ -27,14 +27,14 @@ contract FuelSidechainConsensus is Initializable, OwnableUpgradeable, PausableUp
     }
 
     /// @notice Contract initializer to setup starting values
-    /// @param authorityKey Public key of the block producer authority
-    function initialize(address authorityKey) public initializer {
+    /// @param key Public key of the block producer authority
+    function initialize(address key) public initializer {
         __Pausable_init();
         __Ownable_init();
         __UUPSUpgradeable_init();
 
         // data
-        s_authorityKey = authorityKey;
+        _authorityKey = key;
     }
 
     /////////////////////
@@ -42,9 +42,9 @@ contract FuelSidechainConsensus is Initializable, OwnableUpgradeable, PausableUp
     /////////////////////
 
     /// @notice Sets the PoA key
-    /// @param authorityKey Address of the PoA authority
-    function setAuthorityKey(address authorityKey) external onlyOwner {
-        s_authorityKey = authorityKey;
+    /// @param key Address of the PoA authority
+    function setAuthorityKey(address key) external onlyOwner {
+        _authorityKey = key;
     }
 
     /// @notice Pause block commitments
@@ -61,11 +61,17 @@ contract FuelSidechainConsensus is Initializable, OwnableUpgradeable, PausableUp
     // Public Functions //
     //////////////////////
 
+    /// @notice Gets the currently set PoA key
+    /// @return authority key
+    function authorityKey() public view returns (address) {
+        return _authorityKey;
+    }
+
     /// @notice Verify a given block.
     /// @param blockHash The hash of a block
     /// @param signature The signature over the block hash
     function verifyBlock(bytes32 blockHash, bytes calldata signature) external view whenNotPaused returns (bool) {
-        return CryptographyLib.addressFromSignature(signature, blockHash) == s_authorityKey;
+        return CryptographyLib.addressFromSignature(signature, blockHash) == _authorityKey;
     }
 
     ////////////////////////

--- a/contracts/test/MessageTester.sol
+++ b/contracts/test/MessageTester.sol
@@ -15,7 +15,7 @@ contract MessageTester is FuelMessagesEnabled {
     /// @notice Constructor.
     /// @param fuelMessagePortal The IFuelMessagePortal contract
     constructor(IFuelMessagePortal fuelMessagePortal) {
-        s_fuelMessagePortal = fuelMessagePortal;
+        _fuelMessagePortal = fuelMessagePortal;
     }
 
     /// @notice Message receiving function.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,49 +14,49 @@ const CONTRACTS_RPC_URL = process.env.CONTRACTS_RPC_URL || '';
 const CONTRACTS_DEPLOYER_KEY = process.env.CONTRACTS_DEPLOYER_KEY || '';
 
 const config: HardhatUserConfig = {
-	defaultNetwork: 'hardhat',
-	solidity: {
-		compilers: [
-			{
-				version: '0.8.9',
-				settings: {
-					optimizer: {
-						enabled: true,
-						runs: 10000,
-					},
-				},
-			},
-		],
-	},
-	mocha: {
-		timeout: 180_000,
-	},
-	networks: {
-		hardhat: {
-			accounts: {
-				count: 128,
-			},
-		},
-		localhost: {
-			url: 'http://127.0.0.1:8545/',
-		},
-		custom: {
-			url: 'http://127.0.0.1:8545/',
-		},
-	},
-	etherscan: {
-		apiKey: ETHERSCAN_API_KEY,
-	},
+    defaultNetwork: 'hardhat',
+    solidity: {
+        compilers: [
+            {
+                version: '0.8.9',
+                settings: {
+                    optimizer: {
+                        enabled: true,
+                        runs: 10000,
+                    },
+                },
+            },
+        ],
+    },
+    mocha: {
+        timeout: 180_000,
+    },
+    networks: {
+        hardhat: {
+            accounts: {
+                count: 128,
+            },
+        },
+        localhost: {
+            url: 'http://127.0.0.1:8545/',
+        },
+        custom: {
+            url: 'http://127.0.0.1:8545/',
+        },
+    },
+    etherscan: {
+        apiKey: ETHERSCAN_API_KEY,
+    },
 };
 
 // Override network configuration with environment variables
 if (CONTRACTS_RPC_URL && CONTRACTS_DEPLOYER_KEY && config.networks && config.networks.custom) {
-	config.networks.custom = {
-		accounts: [CONTRACTS_DEPLOYER_KEY],
-		url: CONTRACTS_RPC_URL,
-		live: true,
-	};
-	if (process.env.CONTRACTS_GAS_PRICE) config.networks.custom.gasPrice = parseInt(process.env.CONTRACTS_GAS_PRICE);
+    config.networks.custom = {
+        accounts: [CONTRACTS_DEPLOYER_KEY],
+        url: CONTRACTS_RPC_URL,
+        live: true,
+    };
+    if (process.env.CONTRACTS_GAS_PRICE) config.networks.custom.gasPrice = parseInt(process.env.CONTRACTS_GAS_PRICE);
 }
 
 export default config;

--- a/protocol/cryptography.ts
+++ b/protocol/cryptography.ts
@@ -2,5 +2,5 @@ import { utils, BytesLike } from 'ethers';
 
 // The primary hash function for Fuel.
 export default function hash(data: BytesLike): string {
-	return utils.sha256(data);
+    return utils.sha256(data);
 }

--- a/protocol/harness.ts
+++ b/protocol/harness.ts
@@ -4,7 +4,7 @@ import { ethers, upgrades } from 'hardhat';
 import { BigNumber as BN, Signer } from 'ethers';
 import { FuelSidechainConsensus } from '../typechain/FuelSidechainConsensus.d';
 import { FuelMessagePortal } from '../typechain/FuelMessagePortal.d';
-import { L1ERC20Gateway } from '../typechain/L1ERC20Gateway.d';
+import { FuelERC20Gateway } from '../typechain/FuelERC20Gateway.d';
 import { Token } from '../typechain/Token.d';
 import { computeAddress, SigningKey } from 'ethers/lib/utils';
 
@@ -13,158 +13,158 @@ export const DEFAULT_POA_KEY = '0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e
 
 // All deployable contracts.
 export interface DeployedContracts {
-	fuelMessagePortal: FuelMessagePortal;
-	fuelSidechainConsensus: FuelSidechainConsensus;
-	l1ERC20Gateway: L1ERC20Gateway;
+    fuelMessagePortal: FuelMessagePortal;
+    fuelSidechainConsensus: FuelSidechainConsensus;
+    fuelERC20Gateway: FuelERC20Gateway;
 }
 export interface DeployedContractAddresses {
-	FuelMessagePortal: string;
-	FuelSidechainConsensus: string;
-	L1ERC20Gateway: string;
-	FuelMessagePortal_impl: string;
-	FuelSidechainConsensus_impl: string;
-	L1ERC20Gateway_impl: string;
+    FuelMessagePortal: string;
+    FuelSidechainConsensus: string;
+    FuelERC20Gateway: string;
+    FuelMessagePortal_impl: string;
+    FuelSidechainConsensus_impl: string;
+    FuelERC20Gateway_impl: string;
 }
 
 // The harness object.
 export interface HarnessObject {
-	contractAddresses: DeployedContractAddresses;
-	fuelMessagePortal: FuelMessagePortal;
-	fuelSidechain: FuelSidechainConsensus;
-	l1ERC20Gateway: L1ERC20Gateway;
-	token: Token;
-	poaSigner: SigningKey;
-	poaSignerAddress: string;
-	signer: string;
-	signers: Array<Signer>;
-	addresses: Array<string>;
-	initialTokenAmount: BN;
+    contractAddresses: DeployedContractAddresses;
+    fuelMessagePortal: FuelMessagePortal;
+    fuelSidechain: FuelSidechainConsensus;
+    fuelERC20Gateway: FuelERC20Gateway;
+    token: Token;
+    poaSigner: SigningKey;
+    poaSignerAddress: string;
+    signer: string;
+    signers: Array<Signer>;
+    addresses: Array<string>;
+    initialTokenAmount: BN;
 }
 
 // Gets a blank set of addresses for the deployed contracts.
 export function getBlankAddresses(): DeployedContractAddresses {
-	return {
-		FuelSidechainConsensus: '',
-		FuelMessagePortal: '',
-		L1ERC20Gateway: '',
-		FuelSidechainConsensus_impl: '',
-		FuelMessagePortal_impl: '',
-		L1ERC20Gateway_impl: '',
-	};
+    return {
+        FuelSidechainConsensus: '',
+        FuelMessagePortal: '',
+        FuelERC20Gateway: '',
+        FuelSidechainConsensus_impl: '',
+        FuelMessagePortal_impl: '',
+        FuelERC20Gateway_impl: '',
+    };
 }
 
 // Gets the addresses of the deployed contracts.
 export async function getContractAddresses(contracts: DeployedContracts): Promise<DeployedContractAddresses> {
-	return {
-		FuelSidechainConsensus: contracts.fuelSidechainConsensus.address,
-		FuelMessagePortal: contracts.fuelMessagePortal.address,
-		L1ERC20Gateway: contracts.l1ERC20Gateway.address,
-		FuelSidechainConsensus_impl: await upgrades.erc1967.getImplementationAddress(
-			contracts.fuelSidechainConsensus.address
-		),
-		FuelMessagePortal_impl: await upgrades.erc1967.getImplementationAddress(contracts.fuelMessagePortal.address),
-		L1ERC20Gateway_impl: await upgrades.erc1967.getImplementationAddress(contracts.l1ERC20Gateway.address),
-	};
+    return {
+        FuelSidechainConsensus: contracts.fuelSidechainConsensus.address,
+        FuelMessagePortal: contracts.fuelMessagePortal.address,
+        FuelERC20Gateway: contracts.fuelERC20Gateway.address,
+        FuelSidechainConsensus_impl: await upgrades.erc1967.getImplementationAddress(
+            contracts.fuelSidechainConsensus.address
+        ),
+        FuelMessagePortal_impl: await upgrades.erc1967.getImplementationAddress(contracts.fuelMessagePortal.address),
+        FuelERC20Gateway_impl: await upgrades.erc1967.getImplementationAddress(contracts.fuelERC20Gateway.address),
+    };
 }
 
 // The setup method for Fuel.
 export async function setupFuel(): Promise<HarnessObject> {
-	// Create test POA signer
-	const poaSigner = new SigningKey(DEFAULT_POA_KEY);
-	const poaSignerAddress = computeAddress(poaSigner.privateKey);
+    // Create test POA signer
+    const poaSigner = new SigningKey(DEFAULT_POA_KEY);
+    const poaSignerAddress = computeAddress(poaSigner.privateKey);
 
-	// Get signers
-	const signer = (await ethers.getSigners())[0].address;
-	const signers = await ethers.getSigners();
+    // Get signers
+    const signer = (await ethers.getSigners())[0].address;
+    const signers = await ethers.getSigners();
 
-	// Deploy Fuel contracts
-	const contracts = await deployFuel(poaSignerAddress);
+    // Deploy Fuel contracts
+    const contracts = await deployFuel(poaSignerAddress);
 
-	// Deploy a token for gateway testing
-	const tokenFactory = await ethers.getContractFactory('Token');
-	const token: Token = (await tokenFactory.deploy()) as Token;
-	await token.deployed();
+    // Deploy a token for gateway testing
+    const tokenFactory = await ethers.getContractFactory('Token');
+    const token: Token = (await tokenFactory.deploy()) as Token;
+    await token.deployed();
 
-	// Mint some dummy token for deposit testing
-	const initialTokenAmount = ethers.utils.parseEther('1000000');
-	for (let i = 0; i < signers.length; i += 1) {
-		await token.mint(await signers[i].getAddress(), initialTokenAmount);
-	}
+    // Mint some dummy token for deposit testing
+    const initialTokenAmount = ethers.utils.parseEther('1000000');
+    for (let i = 0; i < signers.length; i += 1) {
+        await token.mint(await signers[i].getAddress(), initialTokenAmount);
+    }
 
-	// Return the Fuel harness object
-	return {
-		contractAddresses: await getContractAddresses(contracts),
-		fuelSidechain: contracts.fuelSidechainConsensus,
-		fuelMessagePortal: contracts.fuelMessagePortal,
-		l1ERC20Gateway: contracts.l1ERC20Gateway,
-		token,
-		poaSigner,
-		poaSignerAddress,
-		signer,
-		signers,
-		addresses: (await ethers.getSigners()).map((v) => v.address),
-		initialTokenAmount,
-	};
+    // Return the Fuel harness object
+    return {
+        contractAddresses: await getContractAddresses(contracts),
+        fuelSidechain: contracts.fuelSidechainConsensus,
+        fuelMessagePortal: contracts.fuelMessagePortal,
+        fuelERC20Gateway: contracts.fuelERC20Gateway,
+        token,
+        poaSigner,
+        poaSignerAddress,
+        signer,
+        signers,
+        addresses: (await ethers.getSigners()).map((v) => v.address),
+        initialTokenAmount,
+    };
 }
 
 // The full contract deployment for Fuel.
 export async function deployFuel(poaSignerAddress?: string): Promise<DeployedContracts> {
-	poaSignerAddress = poaSignerAddress || (await ethers.getSigners())[0].address;
+    poaSignerAddress = poaSignerAddress || (await ethers.getSigners())[0].address;
 
-	// Deploy fuel sidechain contract
-	const FuelSidechainConsensus = await ethers.getContractFactory('FuelSidechainConsensus');
-	const fuelSidechainConsensus = (await upgrades.deployProxy(FuelSidechainConsensus, [poaSignerAddress], {
-		initializer: 'initialize',
-	})) as FuelSidechainConsensus;
-	await fuelSidechainConsensus.deployed();
+    // Deploy fuel sidechain contract
+    const FuelSidechainConsensus = await ethers.getContractFactory('FuelSidechainConsensus');
+    const fuelSidechainConsensus = (await upgrades.deployProxy(FuelSidechainConsensus, [poaSignerAddress], {
+        initializer: 'initialize',
+    })) as FuelSidechainConsensus;
+    await fuelSidechainConsensus.deployed();
 
-	// Deploy message portal contract
-	const FuelMessagePortal = await ethers.getContractFactory('FuelMessagePortal');
-	const fuelMessagePortal = (await upgrades.deployProxy(FuelMessagePortal, [fuelSidechainConsensus.address], {
-		initializer: 'initialize',
-	})) as FuelMessagePortal;
-	await fuelMessagePortal.deployed();
+    // Deploy message portal contract
+    const FuelMessagePortal = await ethers.getContractFactory('FuelMessagePortal');
+    const fuelMessagePortal = (await upgrades.deployProxy(FuelMessagePortal, [fuelSidechainConsensus.address], {
+        initializer: 'initialize',
+    })) as FuelMessagePortal;
+    await fuelMessagePortal.deployed();
 
-	// Deploy gateway contract for ERC20 bridging
-	const L1ERC20Gateway = await ethers.getContractFactory('L1ERC20Gateway');
-	const l1ERC20Gateway = (await upgrades.deployProxy(L1ERC20Gateway, [fuelMessagePortal.address], {
-		initializer: 'initialize',
-	})) as L1ERC20Gateway;
-	await l1ERC20Gateway.deployed();
+    // Deploy gateway contract for ERC20 bridging
+    const FuelERC20Gateway = await ethers.getContractFactory('FuelERC20Gateway');
+    const fuelERC20Gateway = (await upgrades.deployProxy(FuelERC20Gateway, [fuelMessagePortal.address], {
+        initializer: 'initialize',
+    })) as FuelERC20Gateway;
+    await fuelERC20Gateway.deployed();
 
-	// Return deployed contracts
-	return {
-		fuelSidechainConsensus,
-		fuelMessagePortal,
-		l1ERC20Gateway,
-	};
+    // Return deployed contracts
+    return {
+        fuelSidechainConsensus,
+        fuelMessagePortal,
+        fuelERC20Gateway,
+    };
 }
 
 // The full contract deployment for Fuel.
 export async function upgradeFuel(
-	contracts: DeployedContractAddresses,
-	signer?: Signer
+    contracts: DeployedContractAddresses,
+    signer?: Signer
 ): Promise<DeployedContractAddresses> {
-	// Upgrade fuel sidechain contract
-	const FuelSidechainConsensus = await ethers.getContractFactory('FuelSidechainConsensus', signer);
-	await upgrades.forceImport(contracts.FuelSidechainConsensus, FuelSidechainConsensus, { kind: 'uups' });
-	await upgrades.upgradeProxy(contracts.FuelSidechainConsensus, FuelSidechainConsensus);
+    // Upgrade fuel sidechain contract
+    const FuelSidechainConsensus = await ethers.getContractFactory('FuelSidechainConsensus', signer);
+    await upgrades.forceImport(contracts.FuelSidechainConsensus, FuelSidechainConsensus, { kind: 'uups' });
+    await upgrades.upgradeProxy(contracts.FuelSidechainConsensus, FuelSidechainConsensus);
 
-	// Upgrade message portal contract
-	const FuelMessagePortal = await ethers.getContractFactory('FuelMessagePortal', signer);
-	await upgrades.forceImport(contracts.FuelMessagePortal, FuelMessagePortal, { kind: 'uups' });
-	await upgrades.upgradeProxy(contracts.FuelMessagePortal, FuelMessagePortal);
+    // Upgrade message portal contract
+    const FuelMessagePortal = await ethers.getContractFactory('FuelMessagePortal', signer);
+    await upgrades.forceImport(contracts.FuelMessagePortal, FuelMessagePortal, { kind: 'uups' });
+    await upgrades.upgradeProxy(contracts.FuelMessagePortal, FuelMessagePortal);
 
-	// Upgrade gateway contract for ERC20 bridging
-	const L1ERC20Gateway = await ethers.getContractFactory('L1ERC20Gateway', signer);
-	await upgrades.forceImport(contracts.L1ERC20Gateway, L1ERC20Gateway, { kind: 'uups' });
-	await upgrades.upgradeProxy(contracts.L1ERC20Gateway, L1ERC20Gateway);
+    // Upgrade gateway contract for ERC20 bridging
+    const FuelERC20Gateway = await ethers.getContractFactory('FuelERC20Gateway', signer);
+    await upgrades.forceImport(contracts.FuelERC20Gateway, FuelERC20Gateway, { kind: 'uups' });
+    await upgrades.upgradeProxy(contracts.FuelERC20Gateway, FuelERC20Gateway);
 
-	// Return deployed contracts
-	contracts.FuelSidechainConsensus_impl = await upgrades.erc1967.getImplementationAddress(
-		contracts.FuelSidechainConsensus
-	);
-	contracts.FuelMessagePortal_impl = await upgrades.erc1967.getImplementationAddress(contracts.FuelMessagePortal);
-	contracts.L1ERC20Gateway_impl = await upgrades.erc1967.getImplementationAddress(contracts.L1ERC20Gateway);
-	return contracts;
+    // Return deployed contracts
+    contracts.FuelSidechainConsensus_impl = await upgrades.erc1967.getImplementationAddress(
+        contracts.FuelSidechainConsensus
+    );
+    contracts.FuelMessagePortal_impl = await upgrades.erc1967.getImplementationAddress(contracts.FuelMessagePortal);
+    contracts.FuelERC20Gateway_impl = await upgrades.erc1967.getImplementationAddress(contracts.FuelERC20Gateway);
+    return contracts;
 }

--- a/protocol/message.ts
+++ b/protocol/message.ts
@@ -3,23 +3,23 @@ import hash from './cryptography';
 
 // The Message structure.
 class Message {
-	constructor(
-		public sender: string,
-		public recipient: string,
-		public amount: BN,
-		public nonce: string,
-		public data: string
-	) {}
+    constructor(
+        public sender: string,
+        public recipient: string,
+        public amount: BN,
+        public nonce: string,
+        public data: string
+    ) {}
 }
 
 // Computes the message ID.
 export function computeMessageId(message: Message): string {
-	return hash(
-		ethers.utils.solidityPack(
-			['bytes32', 'bytes32', 'bytes32', 'uint64', 'bytes'],
-			[message.sender, message.recipient, message.nonce, message.amount, message.data]
-		)
-	);
+    return hash(
+        ethers.utils.solidityPack(
+            ['bytes32', 'bytes32', 'bytes32', 'uint64', 'bytes'],
+            [message.sender, message.recipient, message.nonce, message.amount, message.data]
+        )
+    );
 }
 
 export default Message;

--- a/protocol/sidechainBlock.ts
+++ b/protocol/sidechainBlock.ts
@@ -3,79 +3,79 @@ import hash from './cryptography';
 
 // The BlockHeader structure.
 class BlockHeader {
-	constructor(
-		// Consensus
-		public prevRoot: string,
-		public height: string,
-		public timestamp: string,
+    constructor(
+        // Consensus
+        public prevRoot: string,
+        public height: string,
+        public timestamp: string,
 
-		// Application
-		public daHeight: string,
-		public txCount: string,
-		public outputMessagesCount: string,
-		public txRoot: string,
-		public outputMessagesRoot: string
-	) {}
+        // Application
+        public daHeight: string,
+        public txCount: string,
+        public outputMessagesCount: string,
+        public txRoot: string,
+        public outputMessagesRoot: string
+    ) {}
 }
 
 // Serialize a block application header.
 export function serializeApplicationHeader(blockHeader: BlockHeader): string {
-	return utils.solidityPack(
-		['uint64', 'uint64', 'uint64', 'bytes32', 'bytes32'],
-		[
-			blockHeader.daHeight,
-			blockHeader.txCount,
-			blockHeader.outputMessagesCount,
-			blockHeader.txRoot,
-			blockHeader.outputMessagesRoot,
-		]
-	);
+    return utils.solidityPack(
+        ['uint64', 'uint64', 'uint64', 'bytes32', 'bytes32'],
+        [
+            blockHeader.daHeight,
+            blockHeader.txCount,
+            blockHeader.outputMessagesCount,
+            blockHeader.txRoot,
+            blockHeader.outputMessagesRoot,
+        ]
+    );
 }
 
 // Produce the block application header hash.
 export function computeApplicationHeaderHash(blockHeader: BlockHeader): string {
-	return hash(serializeApplicationHeader(blockHeader));
+    return hash(serializeApplicationHeader(blockHeader));
 }
 
 // Serialize a block consensus header.
 export function serializeConsensusHeader(blockHeader: BlockHeader): string {
-	return utils.solidityPack(
-		['bytes32', 'uint32', 'uint64', 'bytes32'],
-		[blockHeader.prevRoot, blockHeader.height, blockHeader.timestamp, computeApplicationHeaderHash(blockHeader)]
-	);
+    return utils.solidityPack(
+        ['bytes32', 'uint32', 'uint64', 'bytes32'],
+        [blockHeader.prevRoot, blockHeader.height, blockHeader.timestamp, computeApplicationHeaderHash(blockHeader)]
+    );
 }
 
 // Produce the block consensus header hash.
 export function computeConsensusHeaderHash(blockHeader: BlockHeader): string {
-	return hash(serializeConsensusHeader(blockHeader));
+    return hash(serializeConsensusHeader(blockHeader));
 }
 
 // Produce the block ID (aka the consensus header hash).
 export function computeBlockId(blockHeader: BlockHeader): string {
-	return computeConsensusHeaderHash(blockHeader);
+    return computeConsensusHeaderHash(blockHeader);
 }
 
 // The BlockHeader structure with only consensus data.
 export class BlockHeaderLite {
-	constructor(
-		// Consensus
-		public prevRoot: string,
-		public height: string,
-		public timestamp: string,
-		public applicationHash: string
-	) {}
+    constructor(
+        // Consensus
+        public prevRoot: string,
+        public height: string,
+        public timestamp: string,
+        public applicationHash: string
+    ) {}
 }
 
 // Generates the lite version of the block header.
 export function generateBlockHeaderLite(blockHeader: BlockHeader): BlockHeaderLite {
-	const header: BlockHeaderLite = {
-		prevRoot: blockHeader.prevRoot,
-		height: blockHeader.height,
-		timestamp: blockHeader.timestamp,
-		applicationHash: computeApplicationHeaderHash(blockHeader),
-	};
+    const header: BlockHeaderLite = {
+        prevRoot: blockHeader.prevRoot,
+        height: blockHeader.height,
+        timestamp: blockHeader.timestamp,
+        applicationHash: computeApplicationHeaderHash(blockHeader),
+    };
 
-	return header;
+    return header;
 }
 
 export default BlockHeader;

--- a/protocol/utils.ts
+++ b/protocol/utils.ts
@@ -3,37 +3,37 @@ import { BigNumber as BN } from 'ethers';
 import hash from './cryptography';
 
 export function randomAddress(): string {
-	return hash(BN.from(Math.floor(Math.random() * 1_000_000)).toHexString()).slice(0, 42);
+    return hash(BN.from(Math.floor(Math.random() * 1_000_000)).toHexString()).slice(0, 42);
 }
 
 export function randomBytes32(): string {
-	return hash(BN.from(Math.floor(Math.random() * 1_000_000)).toHexString());
+    return hash(BN.from(Math.floor(Math.random() * 1_000_000)).toHexString());
 }
 
 export function randomInt(max: number): number {
-	return Math.floor(Math.random() * max);
+    return Math.floor(Math.random() * max);
 }
 
 export function randomBytes(length: number): string {
-	return hash(BN.from(Math.floor(Math.random() * 1_000_000)).toHexString()).slice(0, length * 2 + 2);
+    return hash(BN.from(Math.floor(Math.random() * 1_000_000)).toHexString()).slice(0, length * 2 + 2);
 }
 
 export function uintToBytes32(i: number): string {
-	const value = BN.from(i).toHexString();
-	let trimmedValue = value.slice(2);
-	trimmedValue = '0'.repeat(64 - trimmedValue.length).concat(trimmedValue);
-	return '0x'.concat(trimmedValue);
+    const value = BN.from(i).toHexString();
+    let trimmedValue = value.slice(2);
+    trimmedValue = '0'.repeat(64 - trimmedValue.length).concat(trimmedValue);
+    return '0x'.concat(trimmedValue);
 }
 
 export function padUint(value: BN): string {
-	// uint256 is encoded as 32 bytes, so pad that string.
-	let trimmedValue = value.toHexString().slice(2);
-	trimmedValue = '0'.repeat(64 - trimmedValue.length).concat(trimmedValue);
-	return '0x'.concat(trimmedValue);
+    // uint256 is encoded as 32 bytes, so pad that string.
+    let trimmedValue = value.toHexString().slice(2);
+    trimmedValue = '0'.repeat(64 - trimmedValue.length).concat(trimmedValue);
+    return '0x'.concat(trimmedValue);
 }
 
 export function padBytes(value: string): string {
-	let trimmedValue = value.slice(2);
-	trimmedValue = '0'.repeat(64 - trimmedValue.length).concat(trimmedValue);
-	return '0x'.concat(trimmedValue);
+    let trimmedValue = value.slice(2);
+    trimmedValue = '0'.repeat(64 - trimmedValue.length).concat(trimmedValue);
+    return '0x'.concat(trimmedValue);
 }

--- a/protocol/validators.ts
+++ b/protocol/validators.ts
@@ -4,15 +4,15 @@ import { SigningKey } from 'ethers/lib/utils';
 
 // Sign a messag with a signer, returning the signature object (v, r, s components)
 export async function componentSign(signer: SigningKey, message: string): Promise<Signature> {
-	const flatSig = await signer.signDigest(ethers.utils.arrayify(message));
-	const sig = ethers.utils.splitSignature(flatSig);
-	return sig;
+    const flatSig = await signer.signDigest(ethers.utils.arrayify(message));
+    const sig = ethers.utils.splitSignature(flatSig);
+    return sig;
 }
 
 // Sign a message with as signer, returning a 64-byte compact ECDSA signature
 export async function compactSign(signer: SigningKey, message: string): Promise<string> {
-	const sig = await componentSign(signer, message);
-	// eslint-disable-next-line no-underscore-dangle
-	const compactSig = sig.r.concat(sig._vs.slice(2));
-	return compactSig;
+    const sig = await componentSign(signer, message);
+    // eslint-disable-next-line no-underscore-dangle
+    const compactSig = sig.r.concat(sig._vs.slice(2));
+    return compactSig;
 }

--- a/scripts/deployAll.ts
+++ b/scripts/deployAll.ts
@@ -1,13 +1,13 @@
 import { ethers } from 'hardhat';
 import { DeployedContractAddresses, DeployedContracts, deployFuel, getContractAddresses } from '../protocol/harness';
 import {
-	isNetworkVerifiable,
-	publishProxySourceVerification,
-	publishImplementationSourceVerification,
-	getNetworkName,
-	saveDeploymentsFile,
-	confirmationPrompt,
-	waitForConfirmations,
+    isNetworkVerifiable,
+    publishProxySourceVerification,
+    publishImplementationSourceVerification,
+    getNetworkName,
+    saveDeploymentsFile,
+    confirmationPrompt,
+    waitForConfirmations,
 } from './utils';
 
 // Script to deploy the Fuel v2 system
@@ -24,68 +24,68 @@ const QUICK_DEPLOY = !!process.env.QUICK_DEPLOY;
 const AUTHORITY_KEY = process.env.AUTHORITY_KEY;
 
 async function main() {
-	// Check that the node is up
-	try {
-		await ethers.provider.getBlockNumber();
-	} catch (e) {
-		throw new Error(
-			`Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
-		);
-	}
+    // Check that the node is up
+    try {
+        await ethers.provider.getBlockNumber();
+    } catch (e) {
+        throw new Error(
+            `Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
+        );
+    }
 
-	// Get the current connected network
-	const networkName = await getNetworkName();
+    // Get the current connected network
+    const networkName = await getNetworkName();
 
-	// Get confirmation
-	let confirm = true;
-	if (!QUICK_DEPLOY) {
-		console.log(''); // eslint-disable-line no-console
-		confirm = await confirmationPrompt(
-			`Are you sure you want to deploy ALL proxy and implementation contracts on "${networkName}" (Y/n)? `
-		);
-	}
-	if (confirm) {
-		// Setup Fuel
-		let contracts: DeployedContracts;
-		let deployments: DeployedContractAddresses;
-		try {
-			console.log('Deploying contracts...'); // eslint-disable-line no-console
-			contracts = await deployFuel(AUTHORITY_KEY ? AUTHORITY_KEY : undefined);
-			deployments = await getContractAddresses(contracts);
-		} catch (e) {
-			throw new Error(
-				`Failed to deploy contracts. Make sure all configuration is correct and the proper permissions are in place.`
-			);
-		}
-		const deployedBlock = await ethers.provider.getBlockNumber();
+    // Get confirmation
+    let confirm = true;
+    if (!QUICK_DEPLOY) {
+        console.log(''); // eslint-disable-line no-console
+        confirm = await confirmationPrompt(
+            `Are you sure you want to deploy ALL proxy and implementation contracts on "${networkName}" (Y/n)? `
+        );
+    }
+    if (confirm) {
+        // Setup Fuel
+        let contracts: DeployedContracts;
+        let deployments: DeployedContractAddresses;
+        try {
+            console.log('Deploying contracts...'); // eslint-disable-line no-console
+            contracts = await deployFuel(AUTHORITY_KEY ? AUTHORITY_KEY : undefined);
+            deployments = await getContractAddresses(contracts);
+        } catch (e) {
+            throw new Error(
+                `Failed to deploy contracts. Make sure all configuration is correct and the proper permissions are in place.`
+            );
+        }
+        const deployedBlock = await ethers.provider.getBlockNumber();
 
-		// Emit the addresses of the deployed contracts
-		console.log('Successfully deployed contracts!\n'); // eslint-disable-line no-console
-		Object.entries(deployments).forEach(([key, value]) => {
-			console.log(`${key}: ${value}`); // eslint-disable-line no-console
-		});
+        // Emit the addresses of the deployed contracts
+        console.log('Successfully deployed contracts!\n'); // eslint-disable-line no-console
+        Object.entries(deployments).forEach(([key, value]) => {
+            console.log(`${key}: ${value}`); // eslint-disable-line no-console
+        });
 
-		// Write deployments to file
-		await saveDeploymentsFile(deployments);
+        // Write deployments to file
+        await saveDeploymentsFile(deployments);
 
-		// Confirm source verification/publishing
-		if (!QUICK_DEPLOY && (await isNetworkVerifiable())) {
-			console.log(''); // eslint-disable-line no-console
-			const confirmVerification = await confirmationPrompt(
-				`Do you want to publish contract source code for verification (Y/n)? `
-			);
-			if (confirmVerification) {
-				await waitForConfirmations(deployedBlock, 5);
-				await publishProxySourceVerification(deployments);
-				await publishImplementationSourceVerification(deployments, true, true, true);
-			}
-		}
-	}
+        // Confirm source verification/publishing
+        if (!QUICK_DEPLOY && (await isNetworkVerifiable())) {
+            console.log(''); // eslint-disable-line no-console
+            const confirmVerification = await confirmationPrompt(
+                `Do you want to publish contract source code for verification (Y/n)? `
+            );
+            if (confirmVerification) {
+                await waitForConfirmations(deployedBlock, 5);
+                await publishProxySourceVerification(deployments);
+                await publishImplementationSourceVerification(deployments, true, true, true);
+            }
+        }
+    }
 }
 
 main()
-	.then(() => process.exit(0))
-	.catch((error) => {
-		console.error(error); // eslint-disable-line no-console
-		process.exit(1);
-	});
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error); // eslint-disable-line no-console
+        process.exit(1);
+    });

--- a/scripts/deployImplementation.ts
+++ b/scripts/deployImplementation.ts
@@ -1,12 +1,12 @@
 import { ethers, upgrades } from 'hardhat';
 import {
-	isNetworkVerifiable,
-	publishImplementationSourceVerification,
-	getNetworkName,
-	loadDeploymentsFile,
-	saveDeploymentsFile,
-	confirmationPrompt,
-	waitForConfirmations,
+    isNetworkVerifiable,
+    publishImplementationSourceVerification,
+    getNetworkName,
+    loadDeploymentsFile,
+    saveDeploymentsFile,
+    confirmationPrompt,
+    waitForConfirmations,
 } from './utils';
 
 // Script to upgrade the Fuel v2 system contracts
@@ -20,99 +20,99 @@ import {
 // You can then connect to localhost (ethers, metamask, etc.) and the Fuel system will be deployed there at the addresses given
 
 async function main() {
-	// Check that the node is up
-	try {
-		await ethers.provider.getBlockNumber();
-	} catch (e) {
-		throw new Error(
-			`Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
-		);
-	}
+    // Check that the node is up
+    try {
+        await ethers.provider.getBlockNumber();
+    } catch (e) {
+        throw new Error(
+            `Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
+        );
+    }
 
-	// Get the current connected network
-	const networkName = await getNetworkName();
+    // Get the current connected network
+    const networkName = await getNetworkName();
 
-	// Read existing deployments file
-	const deployments = await loadDeploymentsFile();
+    // Read existing deployments file
+    const deployments = await loadDeploymentsFile();
 
-	// Get confirmation
-	console.log(''); // eslint-disable-line no-console
-	const confirmFuelSidechainConsensus = await confirmationPrompt(
-		`Are you sure you want to deploy the implementation for FuelSidechainConsensus on "${networkName}" (Y/n)? `
-	);
-	const confirmFuelMessagePortal = await confirmationPrompt(
-		`Are you sure you want to deploy the implementation for FuelMessagePortal on "${networkName}" (Y/n)? `
-	);
-	const confirmL1ERC20Gateway = await confirmationPrompt(
-		`Are you sure you want to deploy the implementation for L1ERC20Gateway on "${networkName}" (Y/n)? `
-	);
+    // Get confirmation
+    console.log(''); // eslint-disable-line no-console
+    const confirmFuelSidechainConsensus = await confirmationPrompt(
+        `Are you sure you want to deploy the implementation for FuelSidechainConsensus on "${networkName}" (Y/n)? `
+    );
+    const confirmFuelMessagePortal = await confirmationPrompt(
+        `Are you sure you want to deploy the implementation for FuelMessagePortal on "${networkName}" (Y/n)? `
+    );
+    const confirmFuelERC20Gateway = await confirmationPrompt(
+        `Are you sure you want to deploy the implementation for FuelERC20Gateway on "${networkName}" (Y/n)? `
+    );
 
-	// Deploy FuelSidechainConsensus implementation
-	let fuelSidechainConsensusAddress = null;
-	if (confirmFuelSidechainConsensus) {
-		console.log('Deploying FuelSidechainConsensus implementation...'); // eslint-disable-line no-console
-		const FuelSidechainConsensus = await ethers.getContractFactory('FuelSidechainConsensus');
-		fuelSidechainConsensusAddress = (await upgrades.deployImplementation(FuelSidechainConsensus)).toString();
-	}
+    // Deploy FuelSidechainConsensus implementation
+    let fuelSidechainConsensusAddress = null;
+    if (confirmFuelSidechainConsensus) {
+        console.log('Deploying FuelSidechainConsensus implementation...'); // eslint-disable-line no-console
+        const FuelSidechainConsensus = await ethers.getContractFactory('FuelSidechainConsensus');
+        fuelSidechainConsensusAddress = (await upgrades.deployImplementation(FuelSidechainConsensus)).toString();
+    }
 
-	// Deploy FuelMessagePortal implementation
-	let fuelMessagePortalAddress = null;
-	if (confirmFuelMessagePortal) {
-		console.log('Deploying FuelMessagePortal implementation...'); // eslint-disable-line no-console
-		const FuelMessagePortal = await ethers.getContractFactory('FuelMessagePortal');
-		fuelMessagePortalAddress = (await upgrades.deployImplementation(FuelMessagePortal)).toString();
-	}
+    // Deploy FuelMessagePortal implementation
+    let fuelMessagePortalAddress = null;
+    if (confirmFuelMessagePortal) {
+        console.log('Deploying FuelMessagePortal implementation...'); // eslint-disable-line no-console
+        const FuelMessagePortal = await ethers.getContractFactory('FuelMessagePortal');
+        fuelMessagePortalAddress = (await upgrades.deployImplementation(FuelMessagePortal)).toString();
+    }
 
-	// Deploy L1ERC20Gateway implementation
-	let l1ERC20GatewayAddress = null;
-	if (confirmL1ERC20Gateway) {
-		console.log('Deploying L1ERC20Gateway implementation...'); // eslint-disable-line no-console
-		const L1ERC20Gateway = await ethers.getContractFactory('L1ERC20Gateway');
-		l1ERC20GatewayAddress = (await upgrades.deployImplementation(L1ERC20Gateway)).toString();
-	}
+    // Deploy FuelERC20Gateway implementation
+    let fuelERC20GatewayAddress = null;
+    if (confirmFuelERC20Gateway) {
+        console.log('Deploying FuelERC20Gateway implementation...'); // eslint-disable-line no-console
+        const FuelERC20Gateway = await ethers.getContractFactory('FuelERC20Gateway');
+        fuelERC20GatewayAddress = (await upgrades.deployImplementation(FuelERC20Gateway)).toString();
+    }
 
-	// Remember the current block so we can wait for confirmation later
-	const deployedBlock = await ethers.provider.getBlockNumber();
+    // Remember the current block so we can wait for confirmation later
+    const deployedBlock = await ethers.provider.getBlockNumber();
 
-	// Emit the addresses of the deployed contracts
-	console.log('Successfully deployed contract implementations!\n'); // eslint-disable-line no-console
-	if (fuelSidechainConsensusAddress) {
-		console.log(`FuelSidechainConsensus: ${fuelSidechainConsensusAddress}`); // eslint-disable-line no-console
-		deployments.FuelSidechainConsensus_impl = fuelSidechainConsensusAddress;
-	}
-	if (fuelMessagePortalAddress) {
-		console.log(`FuelMessagePortal: ${fuelMessagePortalAddress}`); // eslint-disable-line no-console
-		deployments.FuelMessagePortal_impl = fuelMessagePortalAddress;
-	}
-	if (l1ERC20GatewayAddress) {
-		console.log(`L1ERC20Gateway: ${l1ERC20GatewayAddress}`); // eslint-disable-line no-console
-		deployments.L1ERC20Gateway_impl = l1ERC20GatewayAddress;
-	}
+    // Emit the addresses of the deployed contracts
+    console.log('Successfully deployed contract implementations!\n'); // eslint-disable-line no-console
+    if (fuelSidechainConsensusAddress) {
+        console.log(`FuelSidechainConsensus: ${fuelSidechainConsensusAddress}`); // eslint-disable-line no-console
+        deployments.FuelSidechainConsensus_impl = fuelSidechainConsensusAddress;
+    }
+    if (fuelMessagePortalAddress) {
+        console.log(`FuelMessagePortal: ${fuelMessagePortalAddress}`); // eslint-disable-line no-console
+        deployments.FuelMessagePortal_impl = fuelMessagePortalAddress;
+    }
+    if (fuelERC20GatewayAddress) {
+        console.log(`FuelERC20Gateway: ${fuelERC20GatewayAddress}`); // eslint-disable-line no-console
+        deployments.FuelERC20Gateway_impl = fuelERC20GatewayAddress;
+    }
 
-	// Write deployments to file
-	await saveDeploymentsFile(deployments);
+    // Write deployments to file
+    await saveDeploymentsFile(deployments);
 
-	// Confirm source verification/publishing
-	if (await isNetworkVerifiable()) {
-		console.log(''); // eslint-disable-line no-console
-		const confirmVerification = await confirmationPrompt(
-			`Do you want to publish contract source code for verification (Y/n)? `
-		);
-		if (confirmVerification) {
-			await waitForConfirmations(deployedBlock, 5);
-			await publishImplementationSourceVerification(
-				deployments,
-				confirmFuelSidechainConsensus,
-				confirmFuelMessagePortal,
-				confirmL1ERC20Gateway
-			);
-		}
-	}
+    // Confirm source verification/publishing
+    if (await isNetworkVerifiable()) {
+        console.log(''); // eslint-disable-line no-console
+        const confirmVerification = await confirmationPrompt(
+            `Do you want to publish contract source code for verification (Y/n)? `
+        );
+        if (confirmVerification) {
+            await waitForConfirmations(deployedBlock, 5);
+            await publishImplementationSourceVerification(
+                deployments,
+                confirmFuelSidechainConsensus,
+                confirmFuelMessagePortal,
+                confirmFuelERC20Gateway
+            );
+        }
+    }
 }
 
 main()
-	.then(() => process.exit(0))
-	.catch((error) => {
-		console.error(error); // eslint-disable-line no-console
-		process.exit(1);
-	});
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error); // eslint-disable-line no-console
+        process.exit(1);
+    });

--- a/scripts/serveDeployments.ts
+++ b/scripts/serveDeployments.ts
@@ -16,5 +16,5 @@ const app: Express = express();
 app.use('/', express.static('deployments'));
 
 app.listen(port, () => {
-	console.log(`Server is running at https://localhost:${port}`); // eslint-disable-line no-console
+    console.log(`Server is running at https://localhost:${port}`); // eslint-disable-line no-console
 });

--- a/scripts/upgradeAll.ts
+++ b/scripts/upgradeAll.ts
@@ -1,13 +1,13 @@
 import { ethers } from 'hardhat';
 import { upgradeFuel } from '../protocol/harness';
 import {
-	isNetworkVerifiable,
-	publishImplementationSourceVerification,
-	getNetworkName,
-	loadDeploymentsFile,
-	saveDeploymentsFile,
-	confirmationPrompt,
-	waitForConfirmations,
+    isNetworkVerifiable,
+    publishImplementationSourceVerification,
+    getNetworkName,
+    loadDeploymentsFile,
+    saveDeploymentsFile,
+    confirmationPrompt,
+    waitForConfirmations,
 } from './utils';
 
 // Script to upgrade the Fuel v2 system contracts
@@ -23,64 +23,64 @@ import {
 // You can then connect to localhost (ethers, metamask, etc.) and the Fuel system will be deployed there at the addresses given
 
 async function main() {
-	// Check that the node is up
-	try {
-		await ethers.provider.getBlockNumber();
-	} catch (e) {
-		throw new Error(
-			`Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
-		);
-	}
+    // Check that the node is up
+    try {
+        await ethers.provider.getBlockNumber();
+    } catch (e) {
+        throw new Error(
+            `Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
+        );
+    }
 
-	// Get the current connected network
-	const networkName = await getNetworkName();
+    // Get the current connected network
+    const networkName = await getNetworkName();
 
-	// Read existing deployments file
-	const deployments = await loadDeploymentsFile();
+    // Read existing deployments file
+    const deployments = await loadDeploymentsFile();
 
-	// Get confirmation
-	console.log(''); // eslint-disable-line no-console
-	const confirmUpgrade = await confirmationPrompt(
-		`Are you sure you want to upgrade ALL contracts on "${networkName}" (Y/n)? `
-	);
-	if (confirmUpgrade) {
-		// Upgrade Fuel
-		try {
-			console.log('Upgrading contracts...'); // eslint-disable-line no-console
-			await upgradeFuel(deployments);
-		} catch (e) {
-			throw new Error(
-				`Failed to deploy contracts. Make sure all configuration is correct and the proper permissions are in place.`
-			);
-		}
-		const deployedBlock = await ethers.provider.getBlockNumber();
+    // Get confirmation
+    console.log(''); // eslint-disable-line no-console
+    const confirmUpgrade = await confirmationPrompt(
+        `Are you sure you want to upgrade ALL contracts on "${networkName}" (Y/n)? `
+    );
+    if (confirmUpgrade) {
+        // Upgrade Fuel
+        try {
+            console.log('Upgrading contracts...'); // eslint-disable-line no-console
+            await upgradeFuel(deployments);
+        } catch (e) {
+            throw new Error(
+                `Failed to deploy contracts. Make sure all configuration is correct and the proper permissions are in place.`
+            );
+        }
+        const deployedBlock = await ethers.provider.getBlockNumber();
 
-		// Emit the addresses of the deployed contracts
-		console.log('Successfully upgraded contracts!\n'); // eslint-disable-line no-console
-		Object.entries(deployments).forEach(([key, value]) => {
-			console.log(`${key}: ${value}`); // eslint-disable-next-line no-console
-		});
+        // Emit the addresses of the deployed contracts
+        console.log('Successfully upgraded contracts!\n'); // eslint-disable-line no-console
+        Object.entries(deployments).forEach(([key, value]) => {
+            console.log(`${key}: ${value}`); // eslint-disable-next-line no-console
+        });
 
-		// Write deployments to file
-		await saveDeploymentsFile(deployments);
+        // Write deployments to file
+        await saveDeploymentsFile(deployments);
 
-		// Confirm source verification/publishing
-		if (await isNetworkVerifiable()) {
-			console.log(''); // eslint-disable-line no-console
-			const confirmVerification = await confirmationPrompt(
-				`Do you want to publish contract source code for verification (Y/n)? `
-			);
-			if (confirmVerification) {
-				await waitForConfirmations(deployedBlock, 5);
-				await publishImplementationSourceVerification(deployments, true, true, true);
-			}
-		}
-	}
+        // Confirm source verification/publishing
+        if (await isNetworkVerifiable()) {
+            console.log(''); // eslint-disable-line no-console
+            const confirmVerification = await confirmationPrompt(
+                `Do you want to publish contract source code for verification (Y/n)? `
+            );
+            if (confirmVerification) {
+                await waitForConfirmations(deployedBlock, 5);
+                await publishImplementationSourceVerification(deployments, true, true, true);
+            }
+        }
+    }
 }
 
 main()
-	.then(() => process.exit(0))
-	.catch((error) => {
-		console.error(error); // eslint-disable-line no-console
-		process.exit(1);
-	});
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error); // eslint-disable-line no-console
+        process.exit(1);
+    });

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -10,164 +10,164 @@ const DEPLOYMENTS_FILE = './deployments/deployments.*.json';
 
 // Loads the deployment addresses for the currently connected network.
 export async function loadDeploymentsFile(saveTemplateOnNotFound = true): Promise<DeployedContractAddresses> {
-	let fileString: string;
-	const networkName = await getNetworkName();
-	const filename = DEPLOYMENTS_FILE.replace('*', networkName);
-	try {
-		fileString = await fs.readFile(filename, 'utf-8');
-	} catch (e) {
-		if (saveTemplateOnNotFound) {
-			const deployments = getBlankAddresses();
-			await fs.writeFile(filename, JSON.stringify(deployments, null, ' '), 'utf-8');
-		}
-		throw new Error(
-			`Failed to read file "${filename}". Make sure the file "${filename}" is properly set and the contracts have been deployed before upgrading.`
-		);
-	}
-	try {
-		return JSON.parse(fileString);
-	} catch (e) {
-		throw new Error(`Failed to parse file "${filename}". Make sure it's properly formatted.`);
-	}
+    let fileString: string;
+    const networkName = await getNetworkName();
+    const filename = DEPLOYMENTS_FILE.replace('*', networkName);
+    try {
+        fileString = await fs.readFile(filename, 'utf-8');
+    } catch (e) {
+        if (saveTemplateOnNotFound) {
+            const deployments = getBlankAddresses();
+            await fs.writeFile(filename, JSON.stringify(deployments, null, ' '), 'utf-8');
+        }
+        throw new Error(
+            `Failed to read file "${filename}". Make sure the file "${filename}" is properly set and the contracts have been deployed before upgrading.`
+        );
+    }
+    try {
+        return JSON.parse(fileString);
+    } catch (e) {
+        throw new Error(`Failed to parse file "${filename}". Make sure it's properly formatted.`);
+    }
 }
 
 // Saves the deployed addresses.
 export async function saveDeploymentsFile(deployments: DeployedContractAddresses) {
-	const networkName = await getNetworkName();
-	const filename = DEPLOYMENTS_FILE.replace('*', networkName);
-	await fs.writeFile(filename, JSON.stringify(deployments, null, ' '), 'utf-8');
+    const networkName = await getNetworkName();
+    const filename = DEPLOYMENTS_FILE.replace('*', networkName);
+    await fs.writeFile(filename, JSON.stringify(deployments, null, ' '), 'utf-8');
 }
 
 // Gets the name of common EVM netwroks based on the connected networks reported chain ID.
 export async function getNetworkName(): Promise<string> {
-	try {
-		//common list of networks and chain ids can be found here: https://chainlist.org/
-		const network = await ethers.provider.getNetwork();
-		if (network.chainId == 1) return 'mainnet';
-		if (network.chainId == 5) return 'goerli';
-		if (network.chainId == 31337) return 'local';
-		return 'unknown';
-	} catch (e) {
-		throw new Error(`Failed to get network info from RPC "${ethers.provider.connection.url}".`);
-	}
+    try {
+        //common list of networks and chain ids can be found here: https://chainlist.org/
+        const network = await ethers.provider.getNetwork();
+        if (network.chainId == 1) return 'mainnet';
+        if (network.chainId == 5) return 'goerli';
+        if (network.chainId == 31337) return 'local';
+        return 'unknown';
+    } catch (e) {
+        throw new Error(`Failed to get network info from RPC "${ethers.provider.connection.url}".`);
+    }
 }
 
 // Simple confirmation loop for CLI input.
 export async function confirmationPrompt(prompt: string): Promise<boolean> {
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-	});
-	return new Promise(function (resolve) {
-		rl.question(prompt, async function (answer) {
-			rl.close();
-			resolve(answer.trim().toLowerCase() === 'y');
-		});
-	});
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise(function (resolve) {
+        rl.question(prompt, async function (answer) {
+            rl.close();
+            resolve(answer.trim().toLowerCase() === 'y');
+        });
+    });
 }
 
 // Publishes source code for verification of proxy contracts.
 export async function publishProxySourceVerification(deployments: DeployedContractAddresses) {
-	await verifyEtherscan('FuelSidechainConsensus proxy', deployments.FuelSidechainConsensus);
-	await verifyEtherscan('FuelMessagePortal proxy', deployments.FuelMessagePortal);
-	await verifyEtherscan('L1ERC20Gateway proxy', deployments.L1ERC20Gateway);
+    await verifyEtherscan('FuelSidechainConsensus proxy', deployments.FuelSidechainConsensus);
+    await verifyEtherscan('FuelMessagePortal proxy', deployments.FuelMessagePortal);
+    await verifyEtherscan('FuelERC20Gateway proxy', deployments.FuelERC20Gateway);
 
-	await verifySourcifyFromEtherscan('FuelSidechainConsensus proxy', deployments.FuelSidechainConsensus);
-	await verifySourcifyFromEtherscan('FuelMessagePortal proxy', deployments.FuelMessagePortal);
-	await verifySourcifyFromEtherscan('L1ERC20Gateway proxy', deployments.L1ERC20Gateway);
+    await verifySourcifyFromEtherscan('FuelSidechainConsensus proxy', deployments.FuelSidechainConsensus);
+    await verifySourcifyFromEtherscan('FuelMessagePortal proxy', deployments.FuelMessagePortal);
+    await verifySourcifyFromEtherscan('FuelERC20Gateway proxy', deployments.FuelERC20Gateway);
 }
 
 // Publishes source code for verification of implementation contracts.
 export async function publishImplementationSourceVerification(
-	deployments: DeployedContractAddresses,
-	publishFuelSidechainConsensus: boolean,
-	publishFuelMessagePortal: boolean,
-	publishL1ERC20Gateway: boolean
+    deployments: DeployedContractAddresses,
+    publishFuelSidechainConsensus: boolean,
+    publishFuelMessagePortal: boolean,
+    publishFuelERC20Gateway: boolean
 ) {
-	if (publishFuelSidechainConsensus) {
-		await verifyEtherscan('FuelSidechainConsensus implementation', deployments.FuelSidechainConsensus_impl);
-		await verifySourcifyFromEtherscan(
-			'FuelSidechainConsensus implementation',
-			deployments.FuelSidechainConsensus_impl
-		);
-	}
+    if (publishFuelSidechainConsensus) {
+        await verifyEtherscan('FuelSidechainConsensus implementation', deployments.FuelSidechainConsensus_impl);
+        await verifySourcifyFromEtherscan(
+            'FuelSidechainConsensus implementation',
+            deployments.FuelSidechainConsensus_impl
+        );
+    }
 
-	if (publishFuelMessagePortal) {
-		await verifyEtherscan('FuelMessagePortal implementation', deployments.FuelMessagePortal_impl);
-		await verifySourcifyFromEtherscan('FuelMessagePortal implementation', deployments.FuelMessagePortal_impl);
-	}
+    if (publishFuelMessagePortal) {
+        await verifyEtherscan('FuelMessagePortal implementation', deployments.FuelMessagePortal_impl);
+        await verifySourcifyFromEtherscan('FuelMessagePortal implementation', deployments.FuelMessagePortal_impl);
+    }
 
-	if (publishL1ERC20Gateway) {
-		await verifyEtherscan('L1ERC20Gateway implementation', deployments.L1ERC20Gateway_impl);
-		await verifySourcifyFromEtherscan('L1ERC20Gateway implementation', deployments.L1ERC20Gateway_impl);
-	}
+    if (publishFuelERC20Gateway) {
+        await verifyEtherscan('FuelERC20Gateway implementation', deployments.FuelERC20Gateway_impl);
+        await verifySourcifyFromEtherscan('FuelERC20Gateway implementation', deployments.FuelERC20Gateway_impl);
+    }
 }
 
 // Gets if the currently connected network is verifiable.
 export async function isNetworkVerifiable(): Promise<boolean> {
-	const networkName = await getNetworkName();
-	return networkName === 'mainnet' || networkName === 'goerli';
+    const networkName = await getNetworkName();
+    return networkName === 'mainnet' || networkName === 'goerli';
 }
 
 // Waits for the given number of confirmations.
 export async function waitForConfirmations(blockNum: number, confirmations: number) {
-	let currentBlock = await ethers.provider.getBlockNumber();
-	let diff = currentBlock - blockNum;
-	if (diff < confirmations) {
-		process.stdout.write(`Waiting for ${confirmations} block confirmations.`);
-		while (currentBlock - blockNum < confirmations) {
-			process.stdout.write('.');
-			if (currentBlock - blockNum != diff) process.stdout.write(`${confirmations - diff - 1}`);
-			diff = currentBlock - blockNum;
+    let currentBlock = await ethers.provider.getBlockNumber();
+    let diff = currentBlock - blockNum;
+    if (diff < confirmations) {
+        process.stdout.write(`Waiting for ${confirmations} block confirmations.`);
+        while (currentBlock - blockNum < confirmations) {
+            process.stdout.write('.');
+            if (currentBlock - blockNum != diff) process.stdout.write(`${confirmations - diff - 1}`);
+            diff = currentBlock - blockNum;
 
-			await sleep(5000);
-			currentBlock = await ethers.provider.getBlockNumber();
-		}
-		console.log(''); // eslint-disable-line no-console
-	}
+            await sleep(5000);
+            currentBlock = await ethers.provider.getBlockNumber();
+        }
+        console.log(''); // eslint-disable-line no-console
+    }
 }
 
 // Publishes source code verification on Etherscan.
 async function verifyEtherscan(contractName: string, contractAddress: string) {
-	try {
-		console.log(`\nPublishing ${contractName} source verification on Etherscan...`); // eslint-disable-line no-console
-		await hardhat.run('verify:verify', {
-			address: contractAddress,
-			constructorArguments: [],
-		});
-	} catch (e) {
-		let message = 'An uknown issue occurred while verifying on Etherscan.';
-		if (e instanceof Error) message = e.message;
-		console.error(message); // eslint-disable-line no-console
-	}
+    try {
+        console.log(`\nPublishing ${contractName} source verification on Etherscan...`); // eslint-disable-line no-console
+        await hardhat.run('verify:verify', {
+            address: contractAddress,
+            constructorArguments: [],
+        });
+    } catch (e) {
+        let message = 'An uknown issue occurred while verifying on Etherscan.';
+        if (e instanceof Error) message = e.message;
+        console.error(message); // eslint-disable-line no-console
+    }
 }
 
 // Verifies source code on Sourcify from Etherscan.
 async function verifySourcifyFromEtherscan(contractName: string, contractAddress: string) {
-	try {
-		console.log(`\nVerifying ${contractName} source on Sourcify from Etherscan...`); // eslint-disable-line no-console
-		const network = await ethers.provider.getNetwork();
-		const body = { address: contractAddress, chain: network.chainId };
-		const response = await fetch('https://sourcify.dev/server/verify/etherscan', {
-			method: 'post',
-			body: JSON.stringify(body),
-			headers: { 'Content-Type': 'application/json' },
-		});
-		const data = await response.json();
-		if (data.error) throw new Error(data.error);
-		if (data.result) {
-			if (data.result.storageTimestamp) console.log('Contract source code already verified'); // eslint-disable-line no-console
-			if (data.result.status == 'perfect') console.log('Contract source code perfectly verified!'); // eslint-disable-line no-console
-			if (data.result.status == 'partial') console.log('Contract source code partially verified.'); // eslint-disable-line no-console
-		}
-	} catch (e) {
-		let message = 'An uknown issue occurred while verifying on Sourcify.';
-		if (e instanceof Error) message = e.message;
-		console.error(message); // eslint-disable-line no-console
-	}
+    try {
+        console.log(`\nVerifying ${contractName} source on Sourcify from Etherscan...`); // eslint-disable-line no-console
+        const network = await ethers.provider.getNetwork();
+        const body = { address: contractAddress, chain: network.chainId };
+        const response = await fetch('https://sourcify.dev/server/verify/etherscan', {
+            method: 'post',
+            body: JSON.stringify(body),
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const data = await response.json();
+        if (data.error) throw new Error(data.error);
+        if (data.result) {
+            if (data.result.storageTimestamp) console.log('Contract source code already verified'); // eslint-disable-line no-console
+            if (data.result.status == 'perfect') console.log('Contract source code perfectly verified!'); // eslint-disable-line no-console
+            if (data.result.status == 'partial') console.log('Contract source code partially verified.'); // eslint-disable-line no-console
+        }
+    } catch (e) {
+        let message = 'An uknown issue occurred while verifying on Sourcify.';
+        if (e instanceof Error) message = e.message;
+        console.error(message); // eslint-disable-line no-console
+    }
 }
 
 // Sleep for the given number of milliseconds
 function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/scripts/verifyAddress.ts
+++ b/scripts/verifyAddress.ts
@@ -4,70 +4,70 @@ import readline from 'readline';
 // Script to verify the deployed code of the Fuel v2 system contracts
 
 async function main() {
-	// Check that the node is up
-	try {
-		await ethers.provider.getBlockNumber();
-	} catch (e) {
-		throw new Error(
-			`Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
-		);
-	}
+    // Check that the node is up
+    try {
+        await ethers.provider.getBlockNumber();
+    } catch (e) {
+        throw new Error(
+            `Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
+        );
+    }
 
-	// Get the contract address to verify
-	console.log(`\nPlease enter the deployed contract address you would like to verify the source for.`); // eslint-disable-line no-console
-	const contractAddress = await contractAddressPrompt();
+    // Get the contract address to verify
+    console.log(`\nPlease enter the deployed contract address you would like to verify the source for.`); // eslint-disable-line no-console
+    const contractAddress = await contractAddressPrompt();
 
-	// Verify to the project source files
-	try {
-		console.log(`\nVerifying deployed contract source...`); // eslint-disable-line no-console
-		await hardhat.run('verify', {
-			address: contractAddress,
-			constructorArguments: [],
-		});
-	} catch (e) {
-		let message = 'An uknown issue occurred while verifying deployed contract.';
-		if (e instanceof Error) message = e.message;
-		console.error(message); // eslint-disable-line no-console
-	}
+    // Verify to the project source files
+    try {
+        console.log(`\nVerifying deployed contract source...`); // eslint-disable-line no-console
+        await hardhat.run('verify', {
+            address: contractAddress,
+            constructorArguments: [],
+        });
+    } catch (e) {
+        let message = 'An uknown issue occurred while verifying deployed contract.';
+        if (e instanceof Error) message = e.message;
+        console.error(message); // eslint-disable-line no-console
+    }
 }
 
 // Simple CLI input loop for getting a contract address.
 export async function contractAddressPrompt(): Promise<string> {
-	let contractAddress = validateContractAddress(await textPrompt('Contract address: '));
-	if (contractAddress === null) {
-		do {
-			console.log('Invalid contract address.'); // eslint-disable-line no-console
-			contractAddress = validateContractAddress(await textPrompt('Contract address: '));
-		} while (contractAddress === null);
-	}
-	return contractAddress;
+    let contractAddress = validateContractAddress(await textPrompt('Contract address: '));
+    if (contractAddress === null) {
+        do {
+            console.log('Invalid contract address.'); // eslint-disable-line no-console
+            contractAddress = validateContractAddress(await textPrompt('Contract address: '));
+        } while (contractAddress === null);
+    }
+    return contractAddress;
 }
 
 // Simple confirmation loop for CLI input.
 export async function textPrompt(prompt: string): Promise<string> {
-	const rl = readline.createInterface({
-		input: process.stdin,
-		output: process.stdout,
-	});
-	return new Promise(function (resolve) {
-		rl.question(prompt, async function (answer) {
-			rl.close();
-			resolve(answer.trim());
-		});
-	});
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise(function (resolve) {
+        rl.question(prompt, async function (answer) {
+            rl.close();
+            resolve(answer.trim());
+        });
+    });
 }
 
 // Checks if the given contract address is valid (returns null if invalid)
 function validateContractAddress(address: string): string | null {
-	try {
-		return ethers.utils.getAddress(address.toLowerCase());
-	} catch (e) {}
-	return null;
+    try {
+        return ethers.utils.getAddress(address.toLowerCase());
+    } catch (e) {}
+    return null;
 }
 
 main()
-	.then(() => process.exit(0))
-	.catch((error) => {
-		console.error(error); // eslint-disable-line no-console
-		process.exit(1);
-	});
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error); // eslint-disable-line no-console
+        process.exit(1);
+    });

--- a/scripts/verifySource.ts
+++ b/scripts/verifySource.ts
@@ -1,63 +1,63 @@
 import { ethers } from 'hardhat';
 import {
-	loadDeploymentsFile,
-	getNetworkName,
-	confirmationPrompt,
-	publishProxySourceVerification,
-	publishImplementationSourceVerification,
+    loadDeploymentsFile,
+    getNetworkName,
+    confirmationPrompt,
+    publishProxySourceVerification,
+    publishImplementationSourceVerification,
 } from './utils';
 
 // Script to publish source code for verification of the Fuel v2 system contracts
 
 async function main() {
-	// Check that the node is up
-	try {
-		await ethers.provider.getBlockNumber();
-	} catch (e) {
-		throw new Error(
-			`Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
-		);
-	}
+    // Check that the node is up
+    try {
+        await ethers.provider.getBlockNumber();
+    } catch (e) {
+        throw new Error(
+            `Failed to connect to RPC "${ethers.provider.connection.url}". Make sure your environment variables and configuration are correct.`
+        );
+    }
 
-	// Read existing deployments file
-	const deployments = await loadDeploymentsFile();
+    // Read existing deployments file
+    const deployments = await loadDeploymentsFile();
 
-	// Get the current connected network
-	const networkName = await getNetworkName();
+    // Get the current connected network
+    const networkName = await getNetworkName();
 
-	// Get confirmation for proxy contracts
-	console.log(''); // eslint-disable-line no-console
-	const confirmProxies = await confirmationPrompt(
-		`Are you sure you want to publish the verification of source code for ALL contract proxies on "${networkName}" (Y/n)? `
-	);
+    // Get confirmation for proxy contracts
+    console.log(''); // eslint-disable-line no-console
+    const confirmProxies = await confirmationPrompt(
+        `Are you sure you want to publish the verification of source code for ALL contract proxies on "${networkName}" (Y/n)? `
+    );
 
-	// Verify contract implementations
-	if (confirmProxies) await publishProxySourceVerification(deployments);
+    // Verify contract implementations
+    if (confirmProxies) await publishProxySourceVerification(deployments);
 
-	// Get confirmation for implementation contracts
-	console.log(''); // eslint-disable-line no-console
-	const confirmFuelSidechainConsensusImpl = await confirmationPrompt(
-		`Are you sure you want to publish the verification of source code for the FuelSidechainConsensus implementation on "${networkName}" (Y/n)? `
-	);
-	const confirmFuelMessagePortalImpl = await confirmationPrompt(
-		`Are you sure you want to publish the verification of source code for the FuelMessagePortal implementation on "${networkName}" (Y/n)? `
-	);
-	const confirmL1ERC20GatewayImpl = await confirmationPrompt(
-		`Are you sure you want to publish the verification of source code for the L1ERC20Gateway implementation on "${networkName}" (Y/n)? `
-	);
+    // Get confirmation for implementation contracts
+    console.log(''); // eslint-disable-line no-console
+    const confirmFuelSidechainConsensusImpl = await confirmationPrompt(
+        `Are you sure you want to publish the verification of source code for the FuelSidechainConsensus implementation on "${networkName}" (Y/n)? `
+    );
+    const confirmFuelMessagePortalImpl = await confirmationPrompt(
+        `Are you sure you want to publish the verification of source code for the FuelMessagePortal implementation on "${networkName}" (Y/n)? `
+    );
+    const confirmFuelERC20GatewayImpl = await confirmationPrompt(
+        `Are you sure you want to publish the verification of source code for the FuelERC20Gateway implementation on "${networkName}" (Y/n)? `
+    );
 
-	// Verify contract implementations
-	await publishImplementationSourceVerification(
-		deployments,
-		confirmFuelSidechainConsensusImpl,
-		confirmFuelMessagePortalImpl,
-		confirmL1ERC20GatewayImpl
-	);
+    // Verify contract implementations
+    await publishImplementationSourceVerification(
+        deployments,
+        confirmFuelSidechainConsensusImpl,
+        confirmFuelMessagePortalImpl,
+        confirmFuelERC20GatewayImpl
+    );
 }
 
 main()
-	.then(() => process.exit(0))
-	.catch((error) => {
-		console.error(error); // eslint-disable-line no-console
-		process.exit(1);
-	});
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error); // eslint-disable-line no-console
+        process.exit(1);
+    });

--- a/test/ecdsa.ts
+++ b/test/ecdsa.ts
@@ -11,62 +11,62 @@ const { expect } = chai;
 const SECP256K1N = BN.from('0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141');
 
 describe('ECDSA', async () => {
-	let mockCrypto: Contract;
-	let signer: SigningKey;
-	before(async () => {
-		const mockCryptoFactory = await ethers.getContractFactory('MockCryptography');
-		mockCrypto = await mockCryptoFactory.deploy();
-		await mockCrypto.deployed();
+    let mockCrypto: Contract;
+    let signer: SigningKey;
+    before(async () => {
+        const mockCryptoFactory = await ethers.getContractFactory('MockCryptography');
+        mockCrypto = await mockCryptoFactory.deploy();
+        await mockCrypto.deployed();
 
-		signer = new SigningKey('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80');
-	});
+        signer = new SigningKey('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80');
+    });
 
-	it('rejects component signatures with high s-value', async () => {
-		const msg = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-		const sig = await componentSign(signer, msg);
-		const vOrig = BN.from(sig.v).sub(27); // take v as 0 or 1
+    it('rejects component signatures with high s-value', async () => {
+        const msg = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+        const sig = await componentSign(signer, msg);
+        const vOrig = BN.from(sig.v).sub(27); // take v as 0 or 1
 
-		// flip v and ensure it is 27 or 28
-		const vFlipped = vOrig.xor(1).add(27);
-		// flip s to secp256k1n - original s. This defines a unique
-		// signature over the same data, which we want to reject.
-		const sFlipped = SECP256K1N.sub(sig.s);
-		const badSig = { v: vFlipped, r: sig.r, s: sFlipped };
+        // flip v and ensure it is 27 or 28
+        const vFlipped = vOrig.xor(1).add(27);
+        // flip s to secp256k1n - original s. This defines a unique
+        // signature over the same data, which we want to reject.
+        const sFlipped = SECP256K1N.sub(sig.s);
+        const badSig = { v: vFlipped, r: sig.r, s: sFlipped };
 
-		await expect(mockCrypto.addressFromSignatureComponents(badSig.v, badSig.r, badSig.s, msg)).to.be.revertedWith(
-			'signature-invalid-s'
-		);
-	});
+        await expect(mockCrypto.addressFromSignatureComponents(badSig.v, badSig.r, badSig.s, msg)).to.be.revertedWith(
+            'signature-invalid-s'
+        );
+    });
 
-	it('rejects component signatures from the zero address', async () => {
-		const msg = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-		const sig = await componentSign(signer, msg);
-		// an r value < 1 makes the signature invalid. ecrecover will return 0x0
-		const badSig = { v: sig.v, r: ethers.constants.HashZero, s: sig.s };
+    it('rejects component signatures from the zero address', async () => {
+        const msg = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+        const sig = await componentSign(signer, msg);
+        // an r value < 1 makes the signature invalid. ecrecover will return 0x0
+        const badSig = { v: sig.v, r: ethers.constants.HashZero, s: sig.s };
 
-		await expect(mockCrypto.addressFromSignatureComponents(badSig.v, badSig.r, badSig.s, msg)).to.be.revertedWith(
-			'signature-invalid'
-		);
-	});
+        await expect(mockCrypto.addressFromSignatureComponents(badSig.v, badSig.r, badSig.s, msg)).to.be.revertedWith(
+            'signature-invalid'
+        );
+    });
 
-	it('rejects invalid compact signatures', async () => {
-		const msg = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-		const sig = await componentSign(signer, msg);
+    it('rejects invalid compact signatures', async () => {
+        const msg = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+        const sig = await componentSign(signer, msg);
 
-		// an r value < 1 makes the signature invalid. ecrecover will return 0x0
-		const badRValue = ethers.constants.HashZero;
-		// eslint-disable-next-line no-underscore-dangle
-		const badSigCompact = badRValue.concat(sig._vs.slice(2));
-		await expect(mockCrypto.addressFromSignature(badSigCompact, msg)).to.be.revertedWith('signature-invalid');
+        // an r value < 1 makes the signature invalid. ecrecover will return 0x0
+        const badRValue = ethers.constants.HashZero;
+        // eslint-disable-next-line no-underscore-dangle
+        const badSigCompact = badRValue.concat(sig._vs.slice(2));
+        await expect(mockCrypto.addressFromSignature(badSigCompact, msg)).to.be.revertedWith('signature-invalid');
 
-		// signature too short
-		// eslint-disable-next-line no-underscore-dangle
-		const shortSig = sig.r.concat(sig._vs.slice(4));
-		await expect(mockCrypto.addressFromSignature(shortSig, msg)).to.be.revertedWith('signature-invalid-length');
+        // signature too short
+        // eslint-disable-next-line no-underscore-dangle
+        const shortSig = sig.r.concat(sig._vs.slice(4));
+        await expect(mockCrypto.addressFromSignature(shortSig, msg)).to.be.revertedWith('signature-invalid-length');
 
-		// signature too long
-		// eslint-disable-next-line no-underscore-dangle
-		const longSig = sig.r.concat(sig._vs.slice(2)).concat('aa');
-		await expect(mockCrypto.addressFromSignature(longSig, msg)).to.be.revertedWith('signature-invalid-length');
-	});
+        // signature too long
+        // eslint-disable-next-line no-underscore-dangle
+        const longSig = sig.r.concat(sig._vs.slice(2)).concat('aa');
+        await expect(mockCrypto.addressFromSignature(longSig, msg)).to.be.revertedWith('signature-invalid-length');
+    });
 });

--- a/test/erc20Gateway.ts
+++ b/test/erc20Gateway.ts
@@ -17,544 +17,578 @@ const { expect } = chai;
 // Merkle tree node structure
 // TODO: should be importable from @fuel-ts/merkle
 declare class TreeNode {
-	left: number;
-	right: number;
-	parent: number;
-	hash: string;
-	data: string;
-	index: number;
+    left: number;
+    right: number;
+    parent: number;
+    hash: string;
+    data: string;
+    index: number;
 }
 
 // Computes data for message
 function computeMessageData(fuelTokenId: string, tokenId: string, from: string, to: string, amount: number): string {
-	return ethers.utils.solidityPack(
-		['bytes32', 'bytes32', 'bytes32', 'bytes32', 'uint256'],
-		[fuelTokenId, tokenId, from, to, amount]
-	);
+    return ethers.utils.solidityPack(
+        ['bytes32', 'bytes32', 'bytes32', 'bytes32', 'uint256'],
+        [fuelTokenId, tokenId, from, to, amount]
+    );
 }
 
 // Create a simple block
 function createBlock(blockIds: string[], messageIds: string[]): BlockHeader {
-	const tai64Time = BigNumber.from(Math.floor(new Date().getTime() / 1000)).add('4611686018427387914');
-	const header: BlockHeader = {
-		prevRoot: calcRoot(blockIds),
-		height: blockIds.length.toString(),
-		timestamp: tai64Time.toHexString(),
-		daHeight: '0',
-		txCount: '0',
-		outputMessagesCount: messageIds.length.toString(),
-		txRoot: EMPTY,
-		outputMessagesRoot: calcRoot(messageIds),
-	};
+    const tai64Time = BigNumber.from(Math.floor(new Date().getTime() / 1000)).add('4611686018427387914');
+    const header: BlockHeader = {
+        prevRoot: calcRoot(blockIds),
+        height: blockIds.length.toString(),
+        timestamp: tai64Time.toHexString(),
+        daHeight: '0',
+        txCount: '0',
+        outputMessagesCount: messageIds.length.toString(),
+        txRoot: EMPTY,
+        outputMessagesRoot: calcRoot(messageIds),
+    };
 
-	return header;
+    return header;
 }
 
 // Get proof for the leaf
 function getLeafIndexKey(nodes: TreeNode[], data: string): number {
-	for (let n = 0; n < nodes.length; n += 1) {
-		if (nodes[n].data === data) {
-			return nodes[n].index;
-		}
-	}
-	return 0;
+    for (let n = 0; n < nodes.length; n += 1) {
+        if (nodes[n].data === data) {
+            return nodes[n].index;
+        }
+    }
+    return 0;
 }
 
 describe('ERC20 Gateway', async () => {
-	let env: HarnessObject;
+    let env: HarnessObject;
 
-	// Message data
-	const fuelTokenTarget1 = randomBytes32();
-	const fuelTokenTarget2 = randomBytes32();
-	const messageIds: string[] = [];
-	let l1GatewayAddress: string;
-	let tokenAddress: string;
+    // Message data
+    const fuelTokenTarget1 = randomBytes32();
+    const fuelTokenTarget2 = randomBytes32();
+    const messageIds: string[] = [];
+    let gatewayAddress: string;
+    let tokenAddress: string;
 
-	// Messages
-	let messageWithdrawal1: Message;
-	let messageWithdrawal2: Message;
-	let messageWithdrawal3: Message;
-	let messageTooLarge: Message;
-	let messageTooSmall: Message;
-	let messageBadL2Token: Message;
-	let messageBadL1Token: Message;
-	let messageBadSender: Message;
+    // Messages
+    let messageWithdrawal1: Message;
+    let messageWithdrawal2: Message;
+    let messageWithdrawal3: Message;
+    let messageTooLarge: Message;
+    let messageTooSmall: Message;
+    let messageBadL2Token: Message;
+    let messageBadL1Token: Message;
+    let messageBadSender: Message;
 
-	// Arrays of committed block headers and their IDs
-	const blockHeaders: BlockHeader[] = [];
-	const blockIds: string[] = [];
-	const blockSignatures: string[] = [];
+    // Arrays of committed block headers and their IDs
+    const blockHeaders: BlockHeader[] = [];
+    const blockIds: string[] = [];
+    const blockSignatures: string[] = [];
 
-	before(async () => {
-		env = await setupFuel();
+    before(async () => {
+        env = await setupFuel();
 
-		// get data for building messages
-		l1GatewayAddress = env.l1ERC20Gateway.address.split('0x').join('0x000000000000000000000000').toLowerCase();
-		tokenAddress = env.token.address;
+        // get data for building messages
+        gatewayAddress = env.fuelERC20Gateway.address.split('0x').join('0x000000000000000000000000').toLowerCase();
+        tokenAddress = env.token.address;
 
-		// message from trusted sender
-		messageWithdrawal1 = new Message(
-			fuelTokenTarget1,
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [env.addresses[2], tokenAddress, 100])
-		);
-		messageWithdrawal2 = new Message(
-			fuelTokenTarget1,
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [env.addresses[3], tokenAddress, 75])
-		);
-		messageWithdrawal3 = new Message(
-			fuelTokenTarget2,
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [env.addresses[3], tokenAddress, 250])
-		);
-		// message with amount too large
-		messageTooLarge = new Message(
-			fuelTokenTarget2,
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
-				env.addresses[3],
-				tokenAddress,
-				1000,
-			])
-		);
-		// message with zero value
-		messageTooSmall = new Message(
-			fuelTokenTarget2,
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [env.addresses[3], tokenAddress, 0])
-		);
-		// message with bad L2 token
-		messageBadL2Token = new Message(
-			randomBytes32(),
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [env.addresses[3], tokenAddress, 10])
-		);
-		// message with bad L1 token
-		messageBadL1Token = new Message(
-			fuelTokenTarget2,
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
-				env.addresses[3],
-				randomAddress(),
-				10,
-			])
-		);
-		// message from untrusted sender
-		messageBadSender = new Message(
-			randomBytes32(),
-			l1GatewayAddress,
-			BN.from(0),
-			randomBytes32(),
-			env.l1ERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [env.addresses[3], tokenAddress, 250])
-		);
+        // message from trusted sender
+        messageWithdrawal1 = new Message(
+            fuelTokenTarget1,
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
+                env.addresses[2],
+                tokenAddress,
+                100,
+            ])
+        );
+        messageWithdrawal2 = new Message(
+            fuelTokenTarget1,
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
+                env.addresses[3],
+                tokenAddress,
+                75,
+            ])
+        );
+        messageWithdrawal3 = new Message(
+            fuelTokenTarget2,
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
+                env.addresses[3],
+                tokenAddress,
+                250,
+            ])
+        );
+        // message with amount too large
+        messageTooLarge = new Message(
+            fuelTokenTarget2,
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
+                env.addresses[3],
+                tokenAddress,
+                1000,
+            ])
+        );
+        // message with zero value
+        messageTooSmall = new Message(
+            fuelTokenTarget2,
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [env.addresses[3], tokenAddress, 0])
+        );
+        // message with bad L2 token
+        messageBadL2Token = new Message(
+            randomBytes32(),
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
+                env.addresses[3],
+                tokenAddress,
+                10,
+            ])
+        );
+        // message with bad L1 token
+        messageBadL1Token = new Message(
+            fuelTokenTarget2,
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
+                env.addresses[3],
+                randomAddress(),
+                10,
+            ])
+        );
+        // message from untrusted sender
+        messageBadSender = new Message(
+            randomBytes32(),
+            gatewayAddress,
+            BN.from(0),
+            randomBytes32(),
+            env.fuelERC20Gateway.interface.encodeFunctionData('finalizeWithdrawal', [
+                env.addresses[3],
+                tokenAddress,
+                250,
+            ])
+        );
 
-		// compile all message IDs
-		messageIds.push(computeMessageId(messageWithdrawal1));
-		messageIds.push(computeMessageId(messageWithdrawal2));
-		messageIds.push(computeMessageId(messageWithdrawal3));
-		messageIds.push(computeMessageId(messageTooLarge));
-		messageIds.push(computeMessageId(messageTooSmall));
-		messageIds.push(computeMessageId(messageBadL2Token));
-		messageIds.push(computeMessageId(messageBadL1Token));
-		messageIds.push(computeMessageId(messageBadSender));
+        // compile all message IDs
+        messageIds.push(computeMessageId(messageWithdrawal1));
+        messageIds.push(computeMessageId(messageWithdrawal2));
+        messageIds.push(computeMessageId(messageWithdrawal3));
+        messageIds.push(computeMessageId(messageTooLarge));
+        messageIds.push(computeMessageId(messageTooSmall));
+        messageIds.push(computeMessageId(messageBadL2Token));
+        messageIds.push(computeMessageId(messageBadL1Token));
+        messageIds.push(computeMessageId(messageBadSender));
 
-		// create a block
-		const blockHeader = createBlock(blockIds, messageIds);
-		const blockId = computeBlockId(blockHeader);
-		const blockSignature = await compactSign(env.poaSigner, blockId);
+        // create a block
+        const blockHeader = createBlock(blockIds, messageIds);
+        const blockId = computeBlockId(blockHeader);
+        const blockSignature = await compactSign(env.poaSigner, blockId);
 
-		// append block header and Id to arrays
-		blockHeaders.push(blockHeader);
-		blockIds.push(blockId);
-		blockSignatures.push(blockSignature);
+        // append block header and Id to arrays
+        blockHeaders.push(blockHeader);
+        blockIds.push(blockId);
+        blockSignatures.push(blockSignature);
 
-		// set token approval for gateway
-		await env.token.approve(env.l1ERC20Gateway.address, env.initialTokenAmount);
-	});
+        // set token approval for gateway
+        await env.token.approve(env.fuelERC20Gateway.address, env.initialTokenAmount);
+    });
 
-	describe('Verify ownership', async () => {
-		let signer0: string;
-		let signer1: string;
-		before(async () => {
-			signer0 = env.addresses[0];
-			signer1 = env.addresses[1];
-		});
+    describe('Verify ownership', async () => {
+        let signer0: string;
+        let signer1: string;
+        before(async () => {
+            signer0 = env.addresses[0];
+            signer1 = env.addresses[1];
+        });
 
-		it('Should be able to switch owner as owner', async () => {
-			expect(await env.l1ERC20Gateway.owner()).to.not.be.equal(signer1);
+        it('Should be able to switch owner as owner', async () => {
+            expect(await env.fuelERC20Gateway.owner()).to.not.be.equal(signer1);
 
-			// Transfer ownership
-			await expect(env.l1ERC20Gateway.transferOwnership(signer1)).to.not.be.reverted;
-			expect(await env.l1ERC20Gateway.owner()).to.be.equal(signer1);
-		});
+            // Transfer ownership
+            await expect(env.fuelERC20Gateway.transferOwnership(signer1)).to.not.be.reverted;
+            expect(await env.fuelERC20Gateway.owner()).to.be.equal(signer1);
+        });
 
-		it('Should not be able to switch owner as non-owner', async () => {
-			expect(await env.l1ERC20Gateway.owner()).to.be.equal(signer1);
+        it('Should not be able to switch owner as non-owner', async () => {
+            expect(await env.fuelERC20Gateway.owner()).to.be.equal(signer1);
 
-			// Attempt transfer ownership
-			await expect(env.l1ERC20Gateway.transferOwnership(signer0)).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-			expect(await env.l1ERC20Gateway.owner()).to.be.equal(signer1);
-		});
+            // Attempt transfer ownership
+            await expect(env.fuelERC20Gateway.transferOwnership(signer0)).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+            expect(await env.fuelERC20Gateway.owner()).to.be.equal(signer1);
+        });
 
-		it('Should be able to switch owner back', async () => {
-			expect(await env.l1ERC20Gateway.owner()).to.not.be.equal(signer0);
+        it('Should be able to switch owner back', async () => {
+            expect(await env.fuelERC20Gateway.owner()).to.not.be.equal(signer0);
 
-			// Transfer ownership
-			await expect(env.l1ERC20Gateway.connect(env.signers[1]).transferOwnership(signer0)).to.not.be.reverted;
-			expect(await env.l1ERC20Gateway.owner()).to.be.equal(signer0);
-		});
-	});
+            // Transfer ownership
+            await expect(env.fuelERC20Gateway.connect(env.signers[1]).transferOwnership(signer0)).to.not.be.reverted;
+            expect(await env.fuelERC20Gateway.owner()).to.be.equal(signer0);
+        });
+    });
 
-	describe('Make both valid and invalid ERC20 deposits', async () => {
-		let provider: Provider;
-		before(async () => {
-			provider = env.fuelMessagePortal.provider;
-		});
+    describe('Make both valid and invalid ERC20 deposits', async () => {
+        let provider: Provider;
+        before(async () => {
+            provider = env.fuelMessagePortal.provider;
+        });
 
-		it('Should not be able to deposit zero', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
+        it('Should not be able to deposit zero', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            expect(await env.fuelERC20Gateway.tokensDeposited(tokenAddress, fuelTokenTarget1)).to.be.equal(
+                gatewayBalance
+            );
 
-			// Attempt deposit
-			await expect(
-				env.l1ERC20Gateway.deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 0)
-			).to.be.revertedWith('Cannot deposit zero');
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-		});
+            // Attempt deposit
+            await expect(
+                env.fuelERC20Gateway.deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 0)
+            ).to.be.revertedWith('Cannot deposit zero');
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+        });
 
-		it('Should not be able to deposit with zero balance', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
+        it('Should not be able to deposit with zero balance', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            expect(await env.fuelERC20Gateway.tokensDeposited(tokenAddress, fuelTokenTarget1)).to.be.equal(
+                gatewayBalance
+            );
 
-			// Attempt deposit
-			await expect(
-				env.l1ERC20Gateway.connect(env.signers[1]).deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 175)
-			).to.be.revertedWith('ERC20: insufficient allowance');
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-		});
+            // Attempt deposit
+            await expect(
+                env.fuelERC20Gateway
+                    .connect(env.signers[1])
+                    .deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 175)
+            ).to.be.revertedWith('ERC20: insufficient allowance');
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+        });
 
-		it('Should be able to deposit tokens', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
+        it('Should be able to deposit tokens', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            expect(await env.fuelERC20Gateway.tokensDeposited(tokenAddress, fuelTokenTarget1)).to.be.equal(
+                gatewayBalance
+            );
 
-			// Deposit 175 to fuelTokenTarget1
-			await expect(env.l1ERC20Gateway.deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 175)).to.not.be
-				.reverted;
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance.add(175));
+            // Deposit 175 to fuelTokenTarget1
+            await expect(env.fuelERC20Gateway.deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 175)).to.not.be
+                .reverted;
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance.add(175));
 
-			// Deposit 250 to fuelTokenTarget2
-			const toAddress = randomBytes32();
-			await expect(env.l1ERC20Gateway.deposit(toAddress, tokenAddress, fuelTokenTarget2, 250)).to.not.be.reverted;
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance.add(175).add(250));
+            // Deposit 250 to fuelTokenTarget2
+            const toAddress = randomBytes32();
+            await expect(env.fuelERC20Gateway.deposit(toAddress, tokenAddress, fuelTokenTarget2, 250)).to.not.be
+                .reverted;
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(
+                gatewayBalance.add(175).add(250)
+            );
 
-			// Verify SentMessage event to l2contract
-			const messageData = computeMessageData(
-				fuelTokenTarget2,
-				tokenAddress.split('0x').join('0x000000000000000000000000'),
-				env.addresses[0].split('0x').join('0x000000000000000000000000'),
-				toAddress,
-				250
-			);
-			const filter2 = {
-				address: env.fuelMessagePortal.address,
-			};
-			const logs2 = await provider.getLogs(filter2);
-			const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs2[logs2.length - 1]);
-			expect(sentMessageEvent.name).to.equal('SentMessage');
-			expect(sentMessageEvent.args.sender).to.equal(l1GatewayAddress);
-			expect(sentMessageEvent.args.data).to.equal(messageData);
-			expect(sentMessageEvent.args.amount).to.equal(0);
-		});
-	});
+            // Verify SentMessage event to l2contract
+            const messageData = computeMessageData(
+                fuelTokenTarget2,
+                tokenAddress.split('0x').join('0x000000000000000000000000'),
+                env.addresses[0].split('0x').join('0x000000000000000000000000'),
+                toAddress,
+                250
+            );
+            const filter2 = {
+                address: env.fuelMessagePortal.address,
+            };
+            const logs2 = await provider.getLogs(filter2);
+            const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs2[logs2.length - 1]);
+            expect(sentMessageEvent.name).to.equal('SentMessage');
+            expect(sentMessageEvent.args.sender).to.equal(gatewayAddress);
+            expect(sentMessageEvent.args.data).to.equal(messageData);
+            expect(sentMessageEvent.args.amount).to.equal(0);
+        });
+    });
 
-	describe('Make both valid and invalid ERC20 withdrawals', async () => {
-		let messageNodes: TreeNode[];
-		let blockHeader: BlockHeader;
-		let poaSignature: string;
-		before(async () => {
-			messageNodes = constructTree(messageIds);
-			blockHeader = blockHeaders[0];
-			poaSignature = blockSignatures[0];
-		});
+    describe('Make both valid and invalid ERC20 withdrawals', async () => {
+        let messageNodes: TreeNode[];
+        let blockHeader: BlockHeader;
+        let poaSignature: string;
+        before(async () => {
+            messageNodes = constructTree(messageIds);
+            blockHeader = blockHeaders[0];
+            poaSignature = blockSignatures[0];
+        });
 
-		it('Should not be able to directly call finalize', async () => {
-			await expect(
-				env.l1ERC20Gateway.finalizeWithdrawal(env.addresses[2], tokenAddress, BN.from(100))
-			).to.be.revertedWith('Caller is not the portal');
-		});
+        it('Should not be able to directly call finalize', async () => {
+            await expect(
+                env.fuelERC20Gateway.finalizeWithdrawal(env.addresses[2], tokenAddress, BN.from(100))
+            ).to.be.revertedWith('Caller is not the portal');
+        });
 
-		it('Should be able to finalize valid withdrawal through portal', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[2]);
-			const messageID = computeMessageId(messageWithdrawal1);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageWithdrawal1,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance.sub(100));
-			expect(await env.token.balanceOf(env.addresses[2])).to.be.equal(recipientBalance.add(100));
-		});
+        it('Should be able to finalize valid withdrawal through portal', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[2]);
+            const messageID = computeMessageId(messageWithdrawal1);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageWithdrawal1,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance.sub(100));
+            expect(await env.token.balanceOf(env.addresses[2])).to.be.equal(recipientBalance.add(100));
+        });
 
-		it('Should be able to finalize valid withdrawal through portal again', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[3]);
-			const messageID = computeMessageId(messageWithdrawal2);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageWithdrawal2,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance.sub(75));
-			expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance.add(75));
-		});
+        it('Should be able to finalize valid withdrawal through portal again', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[3]);
+            const messageID = computeMessageId(messageWithdrawal2);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageWithdrawal2,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance.sub(75));
+            expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance.add(75));
+        });
 
-		it('Should not be able to finalize withdrawal with more than deposited', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[3]);
-			const messageID = computeMessageId(messageTooLarge);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageTooLarge,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-			expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
-		});
+        it('Should not be able to finalize withdrawal with more than deposited', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[3]);
+            const messageID = computeMessageId(messageTooLarge);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageTooLarge,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+            expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
+        });
 
-		it('Should not be able to finalize withdrawal of zero tokens', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[3]);
-			const messageID = computeMessageId(messageTooSmall);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageTooSmall,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-			expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
-		});
+        it('Should not be able to finalize withdrawal of zero tokens', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[3]);
+            const messageID = computeMessageId(messageTooSmall);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageTooSmall,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+            expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
+        });
 
-		it('Should not be able to finalize withdrawal with bad L2 token', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[3]);
-			const messageID = computeMessageId(messageBadL2Token);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageBadL2Token,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-			expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
-		});
+        it('Should not be able to finalize withdrawal with bad L2 token', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[3]);
+            const messageID = computeMessageId(messageBadL2Token);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageBadL2Token,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+            expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
+        });
 
-		it('Should not be able to finalize withdrawal with bad L1 token', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[3]);
-			const messageID = computeMessageId(messageBadL1Token);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageBadL1Token,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-			expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
-		});
+        it('Should not be able to finalize withdrawal with bad L1 token', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[3]);
+            const messageID = computeMessageId(messageBadL1Token);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageBadL1Token,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+            expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
+        });
 
-		it('Should not be able to finalize withdrawal with bad sender', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[3]);
-			const messageID = computeMessageId(messageBadSender);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageBadSender,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-			expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
-		});
-	});
+        it('Should not be able to finalize withdrawal with bad sender', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[3]);
+            const messageID = computeMessageId(messageBadSender);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageBadSender,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+            expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance);
+        });
+    });
 
-	describe('Verify pause and unpause', async () => {
-		let messageNodes: TreeNode[];
-		let blockHeader: BlockHeader;
-		let poaSignature: string;
-		before(async () => {
-			messageNodes = constructTree(messageIds);
-			blockHeader = blockHeaders[0];
-			poaSignature = blockSignatures[0];
-		});
+    describe('Verify pause and unpause', async () => {
+        let messageNodes: TreeNode[];
+        let blockHeader: BlockHeader;
+        let poaSignature: string;
+        before(async () => {
+            messageNodes = constructTree(messageIds);
+            blockHeader = blockHeaders[0];
+            poaSignature = blockSignatures[0];
+        });
 
-		it('Should not be able to pause as non-owner', async () => {
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(false);
+        it('Should not be able to pause as non-owner', async () => {
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(false);
 
-			// Attempt pause
-			await expect(env.l1ERC20Gateway.connect(env.signers[1]).pause()).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(false);
-		});
+            // Attempt pause
+            await expect(env.fuelERC20Gateway.connect(env.signers[1]).pause()).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(false);
+        });
 
-		it('Should be able to pause as owner', async () => {
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(false);
+        it('Should be able to pause as owner', async () => {
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(false);
 
-			// Pause
-			await expect(env.l1ERC20Gateway.pause()).to.not.be.reverted;
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(true);
-		});
+            // Pause
+            await expect(env.fuelERC20Gateway.pause()).to.not.be.reverted;
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(true);
+        });
 
-		it('Should not be able to unpause as non-owner', async () => {
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(true);
+        it('Should not be able to unpause as non-owner', async () => {
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(true);
 
-			// Attempt unpause
-			await expect(env.l1ERC20Gateway.connect(env.signers[1]).unpause()).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(true);
-		});
+            // Attempt unpause
+            await expect(env.fuelERC20Gateway.connect(env.signers[1]).unpause()).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(true);
+        });
 
-		it('Should not be able to finalize withdrawal when paused', async () => {
-			const messageID = computeMessageId(messageWithdrawal3);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageWithdrawal3,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
+        it('Should not be able to finalize withdrawal when paused', async () => {
+            const messageID = computeMessageId(messageWithdrawal3);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageWithdrawal3,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
 
-		it('Should not be able to deposit when paused', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
+        it('Should not be able to deposit when paused', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
 
-			// Deposit 175 to fuelTokenTarget1
-			await expect(
-				env.l1ERC20Gateway.deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 175)
-			).to.be.revertedWith('Pausable: paused');
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance);
-		});
+            // Deposit 175 to fuelTokenTarget1
+            await expect(
+                env.fuelERC20Gateway.deposit(randomBytes32(), tokenAddress, fuelTokenTarget1, 175)
+            ).to.be.revertedWith('Pausable: paused');
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance);
+        });
 
-		it('Should be able to unpause as owner', async () => {
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(true);
+        it('Should be able to unpause as owner', async () => {
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(true);
 
-			// Unpause
-			await expect(env.l1ERC20Gateway.unpause()).to.not.be.reverted;
-			expect(await env.l1ERC20Gateway.paused()).to.be.equal(false);
-		});
+            // Unpause
+            await expect(env.fuelERC20Gateway.unpause()).to.not.be.reverted;
+            expect(await env.fuelERC20Gateway.paused()).to.be.equal(false);
+        });
 
-		it('Should be able to finalize withdrawal when unpaused', async () => {
-			const gatewayBalance = await env.token.balanceOf(env.l1ERC20Gateway.address);
-			const recipientBalance = await env.token.balanceOf(env.addresses[3]);
-			const messageID = computeMessageId(messageWithdrawal3);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					messageWithdrawal3,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await env.token.balanceOf(env.l1ERC20Gateway.address)).to.be.equal(gatewayBalance.sub(250));
-			expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance.add(250));
-		});
-	});
+        it('Should be able to finalize withdrawal when unpaused', async () => {
+            const gatewayBalance = await env.token.balanceOf(env.fuelERC20Gateway.address);
+            const recipientBalance = await env.token.balanceOf(env.addresses[3]);
+            const messageID = computeMessageId(messageWithdrawal3);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    messageWithdrawal3,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await env.token.balanceOf(env.fuelERC20Gateway.address)).to.be.equal(gatewayBalance.sub(250));
+            expect(await env.token.balanceOf(env.addresses[3])).to.be.equal(recipientBalance.add(250));
+        });
+    });
 });

--- a/test/fuelSidechainConsensus.ts
+++ b/test/fuelSidechainConsensus.ts
@@ -12,165 +12,165 @@ const { expect } = chai;
 
 // Create a simple block
 function createBlock(blockIds: string[], messageIds: string[]): BlockHeader {
-	const tai64Time = BigNumber.from(Math.floor(new Date().getTime() / 1000)).add('4611686018427387914');
-	const header: BlockHeader = {
-		prevRoot: EMPTY,
-		height: blockIds.length.toString(),
-		timestamp: tai64Time.toHexString(),
-		daHeight: '0',
-		txCount: '0',
-		outputMessagesCount: messageIds.length.toString(),
-		txRoot: EMPTY,
-		outputMessagesRoot: EMPTY,
-	};
+    const tai64Time = BigNumber.from(Math.floor(new Date().getTime() / 1000)).add('4611686018427387914');
+    const header: BlockHeader = {
+        prevRoot: EMPTY,
+        height: blockIds.length.toString(),
+        timestamp: tai64Time.toHexString(),
+        daHeight: '0',
+        txCount: '0',
+        outputMessagesCount: messageIds.length.toString(),
+        txRoot: EMPTY,
+        outputMessagesRoot: EMPTY,
+    };
 
-	return header;
+    return header;
 }
 
 describe('Sidechain Consensus', async () => {
-	let env: HarnessObject;
+    let env: HarnessObject;
 
-	// Arrays of committed block headers and their IDs
-	let blockHeader: BlockHeader;
-	let blockId: string;
-	let blockSignature: string;
+    // Arrays of committed block headers and their IDs
+    let blockHeader: BlockHeader;
+    let blockId: string;
+    let blockSignature: string;
 
-	before(async () => {
-		env = await setupFuel();
+    before(async () => {
+        env = await setupFuel();
 
-		// create a block
-		blockHeader = createBlock([], []);
-		blockId = computeBlockId(blockHeader);
-		blockSignature = await compactSign(env.poaSigner, blockId);
-	});
+        // create a block
+        blockHeader = createBlock([], []);
+        blockId = computeBlockId(blockHeader);
+        blockSignature = await compactSign(env.poaSigner, blockId);
+    });
 
-	describe('Verify ownership', async () => {
-		let signer0: string;
-		let signer1: string;
-		before(async () => {
-			signer0 = env.addresses[0];
-			signer1 = env.addresses[1];
-		});
+    describe('Verify ownership', async () => {
+        let signer0: string;
+        let signer1: string;
+        before(async () => {
+            signer0 = env.addresses[0];
+            signer1 = env.addresses[1];
+        });
 
-		it('Should be able to switch owner as owner', async () => {
-			expect(await env.fuelSidechain.owner()).to.not.be.equal(signer1);
+        it('Should be able to switch owner as owner', async () => {
+            expect(await env.fuelSidechain.owner()).to.not.be.equal(signer1);
 
-			// Transfer ownership
-			await expect(env.fuelSidechain.transferOwnership(signer1)).to.not.be.reverted;
-			expect(await env.fuelSidechain.owner()).to.be.equal(signer1);
-		});
+            // Transfer ownership
+            await expect(env.fuelSidechain.transferOwnership(signer1)).to.not.be.reverted;
+            expect(await env.fuelSidechain.owner()).to.be.equal(signer1);
+        });
 
-		it('Should not be able to switch owner as non-owner', async () => {
-			expect(await env.fuelSidechain.owner()).to.be.equal(signer1);
+        it('Should not be able to switch owner as non-owner', async () => {
+            expect(await env.fuelSidechain.owner()).to.be.equal(signer1);
 
-			// Attempt transfer ownership
-			await expect(env.fuelSidechain.transferOwnership(signer0)).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-			expect(await env.fuelSidechain.owner()).to.be.equal(signer1);
-		});
+            // Attempt transfer ownership
+            await expect(env.fuelSidechain.transferOwnership(signer0)).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+            expect(await env.fuelSidechain.owner()).to.be.equal(signer1);
+        });
 
-		it('Should be able to switch owner back', async () => {
-			expect(await env.fuelSidechain.owner()).to.not.be.equal(signer0);
+        it('Should be able to switch owner back', async () => {
+            expect(await env.fuelSidechain.owner()).to.not.be.equal(signer0);
 
-			// Transfer ownership
-			await expect(env.fuelSidechain.connect(env.signers[1]).transferOwnership(signer0)).to.not.be.reverted;
-			expect(await env.fuelSidechain.owner()).to.be.equal(signer0);
-		});
-	});
+            // Transfer ownership
+            await expect(env.fuelSidechain.connect(env.signers[1]).transferOwnership(signer0)).to.not.be.reverted;
+            expect(await env.fuelSidechain.owner()).to.be.equal(signer0);
+        });
+    });
 
-	describe('Verify admin functions', async () => {
-		let signer1: string;
-		before(async () => {
-			signer1 = env.addresses[1];
-		});
+    describe('Verify admin functions', async () => {
+        let signer1: string;
+        before(async () => {
+            signer1 = env.addresses[1];
+        });
 
-		it('Should be able to set authority as owner', async () => {
-			expect(await env.fuelSidechain.s_authorityKey()).to.not.be.equal(signer1);
+        it('Should be able to set authority as owner', async () => {
+            expect(await env.fuelSidechain.authorityKey()).to.not.be.equal(signer1);
 
-			// Set authority
-			await expect(env.fuelSidechain.setAuthorityKey(signer1)).to.not.be.reverted;
-			expect(await env.fuelSidechain.s_authorityKey()).to.be.equal(signer1);
-		});
+            // Set authority
+            await expect(env.fuelSidechain.setAuthorityKey(signer1)).to.not.be.reverted;
+            expect(await env.fuelSidechain.authorityKey()).to.be.equal(signer1);
+        });
 
-		it('Should not be able to set authority as non-owner', async () => {
-			expect(await env.fuelSidechain.s_authorityKey()).to.be.equal(signer1);
+        it('Should not be able to set authority as non-owner', async () => {
+            expect(await env.fuelSidechain.authorityKey()).to.be.equal(signer1);
 
-			// Attempt set authority
-			await expect(
-				env.fuelSidechain.connect(env.signers[1]).setAuthorityKey(env.poaSignerAddress)
-			).to.be.revertedWith('Ownable: caller is not the owner');
-			expect(await env.fuelSidechain.s_authorityKey()).to.be.equal(signer1);
-		});
+            // Attempt set authority
+            await expect(
+                env.fuelSidechain.connect(env.signers[1]).setAuthorityKey(env.poaSignerAddress)
+            ).to.be.revertedWith('Ownable: caller is not the owner');
+            expect(await env.fuelSidechain.authorityKey()).to.be.equal(signer1);
+        });
 
-		it('Should be able to switch authority back', async () => {
-			expect(await env.fuelSidechain.s_authorityKey()).to.not.be.equal(env.poaSignerAddress);
+        it('Should be able to switch authority back', async () => {
+            expect(await env.fuelSidechain.authorityKey()).to.not.be.equal(env.poaSignerAddress);
 
-			// Set authority
-			await expect(env.fuelSidechain.setAuthorityKey(env.poaSignerAddress)).to.not.be.reverted;
-			expect(await env.fuelSidechain.s_authorityKey()).to.be.equal(env.poaSignerAddress);
-		});
-	});
+            // Set authority
+            await expect(env.fuelSidechain.setAuthorityKey(env.poaSignerAddress)).to.not.be.reverted;
+            expect(await env.fuelSidechain.authorityKey()).to.be.equal(env.poaSignerAddress);
+        });
+    });
 
-	describe('Verify valid blocks', async () => {
-		let badSignature: string;
-		before(async () => {
-			const badSigner = new SigningKey('0x44bacb478cbed5efcae784d7bf4f2ff80ac0974bec39a17e36ba4a6b4d238ff9');
-			badSignature = await compactSign(badSigner, blockId);
-		});
+    describe('Verify valid blocks', async () => {
+        let badSignature: string;
+        before(async () => {
+            const badSigner = new SigningKey('0x44bacb478cbed5efcae784d7bf4f2ff80ac0974bec39a17e36ba4a6b4d238ff9');
+            badSignature = await compactSign(badSigner, blockId);
+        });
 
-		it('Should be able to verify valid block', async () => {
-			expect(await env.fuelSidechain.verifyBlock(blockId, blockSignature)).to.be.equal(true);
-		});
+        it('Should be able to verify valid block', async () => {
+            expect(await env.fuelSidechain.verifyBlock(blockId, blockSignature)).to.be.equal(true);
+        });
 
-		it('Should not be able to verify invalid block', async () => {
-			expect(await env.fuelSidechain.verifyBlock(blockId, badSignature)).to.be.equal(false);
-		});
-	});
+        it('Should not be able to verify invalid block', async () => {
+            expect(await env.fuelSidechain.verifyBlock(blockId, badSignature)).to.be.equal(false);
+        });
+    });
 
-	describe('Verify pause and unpause', async () => {
-		it('Should not be able to pause as non-owner', async () => {
-			expect(await env.fuelSidechain.paused()).to.be.equal(false);
+    describe('Verify pause and unpause', async () => {
+        it('Should not be able to pause as non-owner', async () => {
+            expect(await env.fuelSidechain.paused()).to.be.equal(false);
 
-			// Attempt pause
-			await expect(env.fuelSidechain.connect(env.signers[1]).pause()).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-			expect(await env.fuelSidechain.paused()).to.be.equal(false);
-		});
+            // Attempt pause
+            await expect(env.fuelSidechain.connect(env.signers[1]).pause()).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+            expect(await env.fuelSidechain.paused()).to.be.equal(false);
+        });
 
-		it('Should be able to pause as owner', async () => {
-			expect(await env.fuelSidechain.paused()).to.be.equal(false);
+        it('Should be able to pause as owner', async () => {
+            expect(await env.fuelSidechain.paused()).to.be.equal(false);
 
-			// Pause
-			await expect(env.fuelSidechain.pause()).to.not.be.reverted;
-			expect(await env.fuelSidechain.paused()).to.be.equal(true);
-		});
+            // Pause
+            await expect(env.fuelSidechain.pause()).to.not.be.reverted;
+            expect(await env.fuelSidechain.paused()).to.be.equal(true);
+        });
 
-		it('Should not be able to unpause as non-owner', async () => {
-			expect(await env.fuelSidechain.paused()).to.be.equal(true);
+        it('Should not be able to unpause as non-owner', async () => {
+            expect(await env.fuelSidechain.paused()).to.be.equal(true);
 
-			// Attempt unpause
-			await expect(env.fuelSidechain.connect(env.signers[1]).unpause()).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-			expect(await env.fuelSidechain.paused()).to.be.equal(true);
-		});
+            // Attempt unpause
+            await expect(env.fuelSidechain.connect(env.signers[1]).unpause()).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+            expect(await env.fuelSidechain.paused()).to.be.equal(true);
+        });
 
-		it('Should not be able to verify block messages when paused', async () => {
-			await expect(env.fuelSidechain.verifyBlock(blockId, blockSignature)).to.be.revertedWith('Pausable: paused');
-		});
+        it('Should not be able to verify block messages when paused', async () => {
+            await expect(env.fuelSidechain.verifyBlock(blockId, blockSignature)).to.be.revertedWith('Pausable: paused');
+        });
 
-		it('Should be able to unpause as owner', async () => {
-			expect(await env.fuelSidechain.paused()).to.be.equal(true);
+        it('Should be able to unpause as owner', async () => {
+            expect(await env.fuelSidechain.paused()).to.be.equal(true);
 
-			// Unpause
-			await expect(env.fuelSidechain.unpause()).to.not.be.reverted;
-			expect(await env.fuelSidechain.paused()).to.be.equal(false);
-		});
+            // Unpause
+            await expect(env.fuelSidechain.unpause()).to.not.be.reverted;
+            expect(await env.fuelSidechain.paused()).to.be.equal(false);
+        });
 
-		it('Should be able to verify block when unpaused', async () => {
-			expect(await env.fuelSidechain.verifyBlock(blockId, blockSignature)).to.be.equal(true);
-		});
-	});
+        it('Should be able to verify block when unpaused', async () => {
+            expect(await env.fuelSidechain.verifyBlock(blockId, blockSignature)).to.be.equal(true);
+        });
+    });
 });

--- a/test/messagesIncoming.ts
+++ b/test/messagesIncoming.ts
@@ -18,1010 +18,1014 @@ const { expect } = chai;
 // Merkle tree node structure
 // TODO: should be importable from @fuel-ts/merkle
 declare class TreeNode {
-	left: number;
-	right: number;
-	parent: number;
-	hash: string;
-	data: string;
-	index: number;
+    left: number;
+    right: number;
+    parent: number;
+    hash: string;
+    data: string;
+    index: number;
 }
 
 // Create a simple block
 function createBlock(blockIds: string[], messageIds: string[]): BlockHeader {
-	const tai64Time = BN.from(Math.floor(new Date().getTime() / 1000)).add('4611686018427387914');
-	const header: BlockHeader = {
-		prevRoot: calcRoot(blockIds),
-		height: blockIds.length.toString(),
-		timestamp: tai64Time.toHexString(),
-		daHeight: '0',
-		txCount: '0',
-		outputMessagesCount: messageIds.length.toString(),
-		txRoot: EMPTY,
-		outputMessagesRoot: calcRoot(messageIds),
-	};
+    const tai64Time = BN.from(Math.floor(new Date().getTime() / 1000)).add('4611686018427387914');
+    const header: BlockHeader = {
+        prevRoot: calcRoot(blockIds),
+        height: blockIds.length.toString(),
+        timestamp: tai64Time.toHexString(),
+        daHeight: '0',
+        txCount: '0',
+        outputMessagesCount: messageIds.length.toString(),
+        txRoot: EMPTY,
+        outputMessagesRoot: calcRoot(messageIds),
+    };
 
-	return header;
+    return header;
 }
 
 // Get proof for the leaf
 function getLeafIndexKey(nodes: TreeNode[], data: string): number {
-	for (let n = 0; n < nodes.length; n += 1) {
-		if (nodes[n].data === data) {
-			return nodes[n].index;
-		}
-	}
-	return 0;
+    for (let n = 0; n < nodes.length; n += 1) {
+        if (nodes[n].data === data) {
+            return nodes[n].index;
+        }
+    }
+    return 0;
 }
 
 describe('Incoming Messages', async () => {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let env: HarnessObject;
-	let fuelBaseAssetDecimals: number;
-	let baseAssetConversion: number;
-
-	// Message data
-	const messageTestData1 = randomBytes32();
-	const messageTestData2 = randomBytes32();
-	const messageTestData3 = randomBytes32();
-	const messageIds: string[] = [];
-	let trustedSenderAddress: string;
-
-	// Testing contracts
-	let messageTester: MessageTester;
-	let messageTesterAddress: string;
-	let fuelMessagePortalContractAddress: string;
-
-	// Messages
-	let message1: Message;
-	let message2: Message;
-	let messageWithAmount: Message;
-	let messageBadSender: Message;
-	let messageBadRecipient: Message;
-	let messageBadData: Message;
-	let messageEOA: Message;
-	let messageEOANoAmount: Message;
-	let messageReentrant1: Message;
-	let messageReentrant2: Message;
-
-	// Arrays of committed block headers and their IDs
-	const blockHeaders: BlockHeader[] = [];
-	const blockIds: string[] = [];
-	const blockSignatures: string[] = [];
-
-	before(async () => {
-		env = await setupFuel();
-		fuelBaseAssetDecimals = await env.fuelMessagePortal.getFuelBaseAssetDecimals();
-		baseAssetConversion = 10 ** (18 - fuelBaseAssetDecimals);
-
-		// Deploy contracts for message testing.
-		const messageTesterContractFactory = await ethers.getContractFactory('MessageTester');
-		messageTester = (await messageTesterContractFactory.deploy(env.fuelMessagePortal.address)) as MessageTester;
-		await messageTester.deployed();
-		expect(await messageTester.data1()).to.be.equal(0);
-		expect(await messageTester.data2()).to.be.equal(0);
-
-		// get data for building messages
-		messageTesterAddress = messageTester.address.split('0x').join('0x000000000000000000000000');
-		fuelMessagePortalContractAddress = env.fuelMessagePortal.address.split('0x').join('0x000000000000000000000000');
-		trustedSenderAddress = await messageTester.getTrustedSender();
-
-		// message from trusted sender
-		message1 = new Message(
-			trustedSenderAddress,
-			messageTesterAddress,
-			BN.from(0),
-			randomBytes32(),
-			messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData1, messageTestData2])
-		);
-		message2 = new Message(
-			trustedSenderAddress,
-			messageTesterAddress,
-			BN.from(0),
-			randomBytes32(),
-			messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData2, messageTestData1])
-		);
-		// message from trusted sender with amount
-		messageWithAmount = new Message(
-			trustedSenderAddress,
-			messageTesterAddress,
-			ethers.utils.parseEther('0.1').div(baseAssetConversion),
-			randomBytes32(),
-			messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData2, messageTestData3])
-		);
-		// message from untrusted sender
-		messageBadSender = new Message(
-			randomBytes32(),
-			messageTesterAddress,
-			BN.from(0),
-			randomBytes32(),
-			messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData3, messageTestData1])
-		);
-		// message to bad recipient
-		messageBadRecipient = new Message(
-			trustedSenderAddress,
-			env.fuelMessagePortal.address.split('0x').join('0x000000000000000000000000'),
-			BN.from(0),
-			randomBytes32(),
-			messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData2, messageTestData2])
-		);
-		// message with bad data
-		messageBadData = new Message(
-			trustedSenderAddress,
-			messageTesterAddress,
-			BN.from(0),
-			randomBytes32(),
-			randomBytes32()
-		);
-		// message to EOA
-		messageEOA = new Message(
-			randomBytes32(),
-			env.addresses[2].split('0x').join('0x000000000000000000000000'),
-			ethers.utils.parseEther('0.1').div(baseAssetConversion),
-			randomBytes32(),
-			'0x'
-		);
-		// message to EOA no amount
-		messageEOANoAmount = new Message(
-			randomBytes32(),
-			env.addresses[3].split('0x').join('0x000000000000000000000000'),
-			BN.from(0),
-			randomBytes32(),
-			'0x'
-		);
-		// message reentrant
-		const reentrantTestMessageID = computeMessageId(message1);
-		const reentrantTestBlockHeader = createBlock([], [reentrantTestMessageID]);
-		const reentrantTestBlockId = computeBlockId(reentrantTestBlockHeader);
-		const reentrantTestPoaSignature = await compactSign(env.poaSigner, reentrantTestBlockId);
-		const reentrantTestMessageNodes = constructTree([reentrantTestMessageID]);
-		const reentrantTestLeafIndexKey = getLeafIndexKey(reentrantTestMessageNodes, reentrantTestMessageID);
-		const reentrantTestMessageInBlockProof = {
-			key: reentrantTestLeafIndexKey,
-			proof: getProof(reentrantTestMessageNodes, reentrantTestLeafIndexKey),
-		};
-		const reentrantTestData = env.fuelMessagePortal.interface.encodeFunctionData('relayMessageFromFuelBlock', [
-			message1,
-			reentrantTestBlockHeader,
-			reentrantTestMessageInBlockProof,
-			reentrantTestPoaSignature,
-		]);
-		messageReentrant1 = new Message(
-			trustedSenderAddress,
-			fuelMessagePortalContractAddress,
-			BN.from(0),
-			randomBytes32(),
-			reentrantTestData
-		);
-		const reentrantTestPrevBlockNodes = constructTree([reentrantTestBlockId]);
-		const reentrantTestBlockHeader2 = createBlock([reentrantTestBlockId], []);
-		const reentrantTestBlockId2 = computeBlockId(reentrantTestBlockHeader2);
-		const reentrantTestPoaSignature2 = await compactSign(env.poaSigner, reentrantTestBlockId2);
-		const reentrantTestMessageBlockLeafIndexKey = getLeafIndexKey(
-			reentrantTestPrevBlockNodes,
-			reentrantTestBlockId
-		);
-		const reentrantTestBlockInHistoryProof = {
-			key: reentrantTestMessageBlockLeafIndexKey,
-			proof: getProof(reentrantTestPrevBlockNodes, reentrantTestMessageBlockLeafIndexKey),
-		};
-		const reentrantTestData2 = env.fuelMessagePortal.interface.encodeFunctionData('relayMessageFromPrevFuelBlock', [
-			message1,
-			generateBlockHeaderLite(reentrantTestBlockHeader2),
-			reentrantTestBlockHeader,
-			reentrantTestBlockInHistoryProof,
-			reentrantTestMessageInBlockProof,
-			reentrantTestPoaSignature2,
-		]);
-		messageReentrant2 = new Message(
-			trustedSenderAddress,
-			fuelMessagePortalContractAddress,
-			BN.from(0),
-			randomBytes32(),
-			reentrantTestData2
-		);
-
-		// compile all message IDs
-		messageIds.push(computeMessageId(message1));
-		messageIds.push(computeMessageId(message2));
-		messageIds.push(computeMessageId(messageWithAmount));
-		messageIds.push(computeMessageId(messageBadSender));
-		messageIds.push(computeMessageId(messageBadRecipient));
-		messageIds.push(computeMessageId(messageBadData));
-		messageIds.push(computeMessageId(messageEOA));
-		messageIds.push(computeMessageId(messageEOANoAmount));
-		messageIds.push(computeMessageId(messageReentrant1));
-		messageIds.push(computeMessageId(messageReentrant2));
-
-		// create blocks
-		for (let i = 0; i < 500; i++) {
-			const blockHeader = createBlock(blockIds, messageIds);
-			const blockId = computeBlockId(blockHeader);
-			const blockSignature = await compactSign(env.poaSigner, blockId);
-
-			// append block header and Id to arrays
-			blockHeaders.push(blockHeader);
-			blockIds.push(blockId);
-			blockSignatures.push(blockSignature);
-		}
-
-		// make sure the portal has eth to relay
-		await env.fuelMessagePortal.sendETH(EMPTY, {
-			value: ethers.utils.parseEther('0.2'),
-		});
-	});
-
-	describe('Verify access control', async () => {
-		const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
-		const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
-		let signer0: string;
-		let signer1: string;
-		let signer2: string;
-		before(async () => {
-			signer0 = env.addresses[0];
-			signer1 = env.addresses[1];
-			signer2 = env.addresses[2];
-		});
-
-		it('Should be able to grant admin role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
-
-			// Grant admin role
-			await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
-		});
-
-		it('Should be able to renounce admin role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
-
-			// Revoke admin role
-			await expect(env.fuelMessagePortal.renounceRole(defaultAdminRole, signer0)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
-		});
-
-		it('Should not be able to grant admin role as non-admin', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
-
-			// Attempt grant admin role
-			await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer0)).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[0].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
-		});
-
-		it('Should be able to grant then revoke admin role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
-
-			// Grant admin role
-			await expect(env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer0)).to.not.be
-				.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
-
-			// Revoke previous admin
-			await expect(env.fuelMessagePortal.revokeRole(defaultAdminRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
-		});
-
-		it('Should be able to grant pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
-
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.grantRole(pauserRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
-		});
-
-		it('Should not be able to grant permission as pauser', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
-
-			// Attempt grant admin role
-			await expect(
-				env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer2)
-			).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
-
-			// Attempt grant pauser role
-			await expect(
-				env.fuelMessagePortal.connect(env.signers[1]).grantRole(pauserRole, signer2)
-			).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
-		});
-
-		it('Should be able to revoke pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
-
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.revokeRole(pauserRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
-		});
-	});
-
-	describe('Verify admin functions', async () => {
-		const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
-		let messageNodes: TreeNode[];
-		let blockHeader: BlockHeader;
-		let poaSignature: string;
-		before(async () => {
-			messageNodes = constructTree(messageIds);
-			blockHeader = blockHeaders[0];
-			poaSignature = blockSignatures[0];
-		});
-
-		it('Should not be able to set timelock as non-admin', async () => {
-			expect(await env.fuelMessagePortal.s_incomingMessageTimelock()).to.be.equal(BN.from(0));
-
-			// Attempt set timelock
-			await expect(
-				env.fuelMessagePortal.connect(env.signers[1]).setIncomingMessageTimelock(10)
-			).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.s_incomingMessageTimelock()).to.be.equal(BN.from(0));
-		});
-
-		it('Should be able to set the timelock as admin', async () => {
-			const newTimelockValue = 7 * 24 * 60 * 60 * 1000;
-			expect(await env.fuelMessagePortal.s_incomingMessageTimelock()).to.not.be.equal(BN.from(newTimelockValue));
-
-			// Set timelock
-			await expect(env.fuelMessagePortal.setIncomingMessageTimelock(newTimelockValue)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageTimelock()).to.be.equal(BN.from(newTimelockValue));
-		});
-
-		it('Should not be able to relay valid message before timelock', async () => {
-			const messageID = computeMessageId(message1);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					message1,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Timelock not elapsed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-
-			// Remove timelock
-			await expect(env.fuelMessagePortal.setIncomingMessageTimelock(0)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageTimelock()).to.be.equal(BN.from(0));
-		});
-
-		it('Should not get a valid message sender outside of relaying', async () => {
-			await expect(env.fuelMessagePortal.getMessageSender()).to.be.revertedWith('Current message sender not set');
-		});
-	});
-
-	describe('Relay both valid and invalid messages', async () => {
-		let provider: Provider;
-		let prevBlockNodes: TreeNode[];
-		let messageNodes: TreeNode[];
-		let blockHeader: BlockHeader;
-		let poaSignature: string;
-		let prevRootHeader: BlockHeaderLite;
-		let prevRootPoaSignature: string;
-		before(async () => {
-			provider = env.fuelMessagePortal.provider;
-			messageNodes = constructTree(messageIds);
-			blockHeader = blockHeaders[0];
-			poaSignature = blockSignatures[0];
-
-			const prevBlockNodesRootBlockNum = blockIds.length - 1;
-			prevRootHeader = generateBlockHeaderLite(blockHeaders[prevBlockNodesRootBlockNum]);
-			prevRootPoaSignature = blockSignatures[prevBlockNodesRootBlockNum];
-			const prevBlockIds = [];
-			for (let i = 0; i < blockIds.length - 1; i++) prevBlockIds.push(blockIds[i]);
-			prevBlockNodes = constructTree(prevBlockIds);
-		});
-
-		it('Should not be able to call messageable contract directly', async () => {
-			await expect(messageTester.receiveMessage(messageTestData3, messageTestData3)).to.be.revertedWith(
-				'Caller is not the portal'
-			);
-		});
-
-		it('Should not be able to relay message with bad block', async () => {
-			const messageID = computeMessageId(message1);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					message1,
-					blockHeader,
-					messageInBlockProof,
-					randomBytes32()
-				)
-			).to.be.revertedWith('signature-invalid-length');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should not be able to relay message with bad root block', async () => {
-			const messageBlockNum = 258;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(message1);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					message1,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					randomBytes32()
-				)
-			).to.be.revertedWith('signature-invalid-length');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should not be able to relay message with bad proof in root block', async () => {
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			const messageTesterBalance = await provider.getBalance(messageTester.address);
-			const messageBlockNum = 67;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum + 1]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(message1);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					message1,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Invalid block in history proof');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
-			expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
-		});
-
-		it('Should not be able to relay reentrant messages', async () => {
-			const messageBlockNum = 145;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-
-			// re-enter via relayMessageFromFuelBlock
-			const messageID = computeMessageId(messageReentrant1);
-			const messageLeafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: messageLeafIndexKey,
-				proof: getProof(messageNodes, messageLeafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageReentrant1,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-
-			// re-enter via relayMessageFromPrevFuelBlock
-			const messageID2 = computeMessageId(messageReentrant2);
-			const messageLeafIndexKey2 = getLeafIndexKey(messageNodes, messageID2);
-			const messageInBlockProof2 = {
-				key: messageLeafIndexKey2,
-				proof: getProof(messageNodes, messageLeafIndexKey2),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageReentrant2,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof2,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should be able to relay valid message', async () => {
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			const messageTesterBalance = await provider.getBalance(messageTester.address);
-			const messageBlockNum = 145;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(message1);
-			const messageLeafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: messageLeafIndexKey,
-				proof: getProof(messageNodes, messageLeafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					message1,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await messageTester.data1()).to.be.equal(messageTestData1);
-			expect(await messageTester.data2()).to.be.equal(messageTestData2);
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
-			expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
-		});
-
-		it('Should not be able to relay already relayed message', async () => {
-			const messageBlockNum = 68;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(message1);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					message1,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Already relayed');
-		});
-
-		it('Should not be able to relay message with low gas', async () => {
-			const messageBlockNum = 11;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(messageWithAmount);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			const options = {
-				gasLimit: 140000,
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageWithAmount,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature,
-					options
-				)
-			).to.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should be able to relay message with amount', async () => {
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			const messageTesterBalance = await provider.getBalance(messageTester.address);
-			const messageBlockNum = 333;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(messageWithAmount);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageWithAmount,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await messageTester.data1()).to.be.equal(messageTestData2);
-			expect(await messageTester.data2()).to.be.equal(messageTestData3);
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(
-				portalBalance.sub(messageWithAmount.amount.mul(baseAssetConversion))
-			);
-			expect(await provider.getBalance(messageTester.address)).to.be.equal(
-				messageTesterBalance.add(messageWithAmount.amount.mul(baseAssetConversion))
-			);
-		});
-
-		it('Should not be able to relay message from untrusted sender', async () => {
-			const messageBlockNum = 471;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(messageBadSender);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageBadSender,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should not be able to relay message to bad recipient', async () => {
-			const messageBlockNum = 296;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(messageBadRecipient);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageBadRecipient,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should not be able to relay message with bad data', async () => {
-			const messageBlockNum = 321;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(messageBadData);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageBadData,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Message relay failed');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should be able to relay message to EOA', async () => {
-			const accountBalance = await provider.getBalance(env.addresses[2]);
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			const messageBlockNum = 19;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(messageEOA);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageEOA,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await provider.getBalance(env.addresses[2])).to.be.equal(
-				accountBalance.add(messageEOA.amount.mul(baseAssetConversion))
-			);
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(
-				portalBalance.sub(messageEOA.amount.mul(baseAssetConversion))
-			);
-		});
-
-		it('Should be able to relay message to EOA with no amount', async () => {
-			const accountBalance = await provider.getBalance(env.addresses[3]);
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			const messageBlockNum = 25;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(messageEOANoAmount);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					messageEOANoAmount,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await provider.getBalance(env.addresses[3])).to.be.equal(accountBalance);
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
-		});
-
-		it('Should not be able to relay valid message with different amount', async () => {
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			const messageTesterBalance = await provider.getBalance(messageTester.address);
-			const messageBlockNum = 68;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(message2);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			const diffBlock = {
-				sender: message2.sender,
-				recipient: message2.recipient,
-				nonce: message2.nonce,
-				amount: message2.amount.add(ethers.utils.parseEther('1.0')),
-				data: message2.data,
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					diffBlock,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					prevRootPoaSignature
-				)
-			).to.be.revertedWith('Invalid message in block proof');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
-			expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
-		});
-
-		it('Should not be able to relay non-existent message', async () => {
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			const messageTesterBalance = await provider.getBalance(messageTester.address);
-			const messageInBlockProof = {
-				key: 0,
-				proof: [],
-			};
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					message2,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Invalid message in block proof');
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
-			expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
-		});
-	});
-
-	describe('Verify pause and unpause', async () => {
-		const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
-		const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
-		let messageNodes: TreeNode[];
-		let prevBlockNodes: TreeNode[];
-		let blockHeader: BlockHeader;
-		let prevRootHeader: BlockHeaderLite;
-		let poaSignature: string;
-		before(async () => {
-			messageNodes = constructTree(messageIds);
-			blockHeader = blockHeaders[0];
-			poaSignature = blockSignatures[0];
-			const prevBlockNodesRootBlockNum = blockIds.length - 1;
-			prevRootHeader = generateBlockHeaderLite(blockHeaders[prevBlockNodesRootBlockNum]);
-			const prevBlockIds = [];
-			for (let i = 0; i < blockIds.length - 1; i++) prevBlockIds.push(blockIds[i]);
-			prevBlockNodes = constructTree(prevBlockIds);
-		});
-
-		it('Should be able to grant pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
-
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.grantRole(pauserRole, env.addresses[2])).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
-		});
-
-		it('Should not be able to pause as non-pauser', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
-
-			// Attempt pause
-			await expect(env.fuelMessagePortal.connect(env.signers[1]).pause()).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${pauserRole}`
-			);
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
-		});
-
-		it('Should be able to pause as pauser', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
-
-			// Pause
-			await expect(env.fuelMessagePortal.connect(env.signers[2]).pause()).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-		});
-
-		it('Should not be able to unpause as pauser (and not admin)', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-
-			// Attempt unpause
-			await expect(env.fuelMessagePortal.connect(env.signers[2]).unpause()).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[2].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-		});
-
-		it('Should not be able to unpause as non-admin', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-
-			// Attempt unpause
-			await expect(env.fuelMessagePortal.connect(env.signers[1]).unpause()).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-		});
-
-		it('Should not be able to relay messages when paused', async () => {
-			const messageBlockNum = 258;
-			const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
-			const blockInHistoryProof = {
-				key: messageBlockLeafIndexKey,
-				proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
-			};
-			const messageID = computeMessageId(message2);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					message2,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.be.revertedWith('Pausable: paused');
-			await expect(
-				env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
-					message2,
-					prevRootHeader,
-					blockHeaders[messageBlockNum],
-					blockInHistoryProof,
-					messageInBlockProof,
-					randomBytes32()
-				)
-			).to.be.revertedWith('Pausable: paused');
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-		});
-
-		it('Should be able to unpause as admin', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-
-			// Unpause
-			await expect(env.fuelMessagePortal.unpause()).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
-		});
-
-		it('Should be able to relay message when unpaused', async () => {
-			const messageID = computeMessageId(message2);
-			const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
-			const messageInBlockProof = {
-				key: leafIndexKey,
-				proof: getProof(messageNodes, leafIndexKey),
-			};
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(false);
-			await expect(
-				env.fuelMessagePortal.relayMessageFromFuelBlock(
-					message2,
-					blockHeader,
-					messageInBlockProof,
-					poaSignature
-				)
-			).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.s_incomingMessageSuccessful(messageID)).to.be.equal(true);
-			expect(await messageTester.data1()).to.be.equal(messageTestData2);
-			expect(await messageTester.data2()).to.be.equal(messageTestData1);
-		});
-
-		it('Should be able to revoke pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
-
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.revokeRole(pauserRole, env.addresses[2])).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
-		});
-	});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let env: HarnessObject;
+    let fuelBaseAssetDecimals: number;
+    let baseAssetConversion: number;
+
+    // Message data
+    const messageTestData1 = randomBytes32();
+    const messageTestData2 = randomBytes32();
+    const messageTestData3 = randomBytes32();
+    const messageIds: string[] = [];
+    let trustedSenderAddress: string;
+
+    // Testing contracts
+    let messageTester: MessageTester;
+    let messageTesterAddress: string;
+    let fuelMessagePortalContractAddress: string;
+
+    // Messages
+    let message1: Message;
+    let message2: Message;
+    let messageWithAmount: Message;
+    let messageBadSender: Message;
+    let messageBadRecipient: Message;
+    let messageBadData: Message;
+    let messageEOA: Message;
+    let messageEOANoAmount: Message;
+    let messageReentrant1: Message;
+    let messageReentrant2: Message;
+
+    // Arrays of committed block headers and their IDs
+    const blockHeaders: BlockHeader[] = [];
+    const blockIds: string[] = [];
+    const blockSignatures: string[] = [];
+
+    before(async () => {
+        env = await setupFuel();
+        fuelBaseAssetDecimals = await env.fuelMessagePortal.fuelBaseAssetDecimals();
+        baseAssetConversion = 10 ** (18 - fuelBaseAssetDecimals);
+
+        // Deploy contracts for message testing.
+        const messageTesterContractFactory = await ethers.getContractFactory('MessageTester');
+        messageTester = (await messageTesterContractFactory.deploy(env.fuelMessagePortal.address)) as MessageTester;
+        await messageTester.deployed();
+        expect(await messageTester.data1()).to.be.equal(0);
+        expect(await messageTester.data2()).to.be.equal(0);
+
+        // get data for building messages
+        messageTesterAddress = messageTester.address.split('0x').join('0x000000000000000000000000');
+        fuelMessagePortalContractAddress = env.fuelMessagePortal.address.split('0x').join('0x000000000000000000000000');
+        trustedSenderAddress = await messageTester.getTrustedSender();
+
+        // message from trusted sender
+        message1 = new Message(
+            trustedSenderAddress,
+            messageTesterAddress,
+            BN.from(0),
+            randomBytes32(),
+            messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData1, messageTestData2])
+        );
+        message2 = new Message(
+            trustedSenderAddress,
+            messageTesterAddress,
+            BN.from(0),
+            randomBytes32(),
+            messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData2, messageTestData1])
+        );
+        // message from trusted sender with amount
+        messageWithAmount = new Message(
+            trustedSenderAddress,
+            messageTesterAddress,
+            ethers.utils.parseEther('0.1').div(baseAssetConversion),
+            randomBytes32(),
+            messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData2, messageTestData3])
+        );
+        // message from untrusted sender
+        messageBadSender = new Message(
+            randomBytes32(),
+            messageTesterAddress,
+            BN.from(0),
+            randomBytes32(),
+            messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData3, messageTestData1])
+        );
+        // message to bad recipient
+        messageBadRecipient = new Message(
+            trustedSenderAddress,
+            env.fuelMessagePortal.address.split('0x').join('0x000000000000000000000000'),
+            BN.from(0),
+            randomBytes32(),
+            messageTester.interface.encodeFunctionData('receiveMessage', [messageTestData2, messageTestData2])
+        );
+        // message with bad data
+        messageBadData = new Message(
+            trustedSenderAddress,
+            messageTesterAddress,
+            BN.from(0),
+            randomBytes32(),
+            randomBytes32()
+        );
+        // message to EOA
+        messageEOA = new Message(
+            randomBytes32(),
+            env.addresses[2].split('0x').join('0x000000000000000000000000'),
+            ethers.utils.parseEther('0.1').div(baseAssetConversion),
+            randomBytes32(),
+            '0x'
+        );
+        // message to EOA no amount
+        messageEOANoAmount = new Message(
+            randomBytes32(),
+            env.addresses[3].split('0x').join('0x000000000000000000000000'),
+            BN.from(0),
+            randomBytes32(),
+            '0x'
+        );
+        // message reentrant
+        const reentrantTestMessageID = computeMessageId(message1);
+        const reentrantTestBlockHeader = createBlock([], [reentrantTestMessageID]);
+        const reentrantTestBlockId = computeBlockId(reentrantTestBlockHeader);
+        const reentrantTestPoaSignature = await compactSign(env.poaSigner, reentrantTestBlockId);
+        const reentrantTestMessageNodes = constructTree([reentrantTestMessageID]);
+        const reentrantTestLeafIndexKey = getLeafIndexKey(reentrantTestMessageNodes, reentrantTestMessageID);
+        const reentrantTestMessageInBlockProof = {
+            key: reentrantTestLeafIndexKey,
+            proof: getProof(reentrantTestMessageNodes, reentrantTestLeafIndexKey),
+        };
+        const reentrantTestData = env.fuelMessagePortal.interface.encodeFunctionData('relayMessageFromFuelBlock', [
+            message1,
+            reentrantTestBlockHeader,
+            reentrantTestMessageInBlockProof,
+            reentrantTestPoaSignature,
+        ]);
+        messageReentrant1 = new Message(
+            trustedSenderAddress,
+            fuelMessagePortalContractAddress,
+            BN.from(0),
+            randomBytes32(),
+            reentrantTestData
+        );
+        const reentrantTestPrevBlockNodes = constructTree([reentrantTestBlockId]);
+        const reentrantTestBlockHeader2 = createBlock([reentrantTestBlockId], []);
+        const reentrantTestBlockId2 = computeBlockId(reentrantTestBlockHeader2);
+        const reentrantTestPoaSignature2 = await compactSign(env.poaSigner, reentrantTestBlockId2);
+        const reentrantTestMessageBlockLeafIndexKey = getLeafIndexKey(
+            reentrantTestPrevBlockNodes,
+            reentrantTestBlockId
+        );
+        const reentrantTestBlockInHistoryProof = {
+            key: reentrantTestMessageBlockLeafIndexKey,
+            proof: getProof(reentrantTestPrevBlockNodes, reentrantTestMessageBlockLeafIndexKey),
+        };
+        const reentrantTestData2 = env.fuelMessagePortal.interface.encodeFunctionData('relayMessageFromPrevFuelBlock', [
+            message1,
+            generateBlockHeaderLite(reentrantTestBlockHeader2),
+            reentrantTestBlockHeader,
+            reentrantTestBlockInHistoryProof,
+            reentrantTestMessageInBlockProof,
+            reentrantTestPoaSignature2,
+        ]);
+        messageReentrant2 = new Message(
+            trustedSenderAddress,
+            fuelMessagePortalContractAddress,
+            BN.from(0),
+            randomBytes32(),
+            reentrantTestData2
+        );
+
+        // compile all message IDs
+        messageIds.push(computeMessageId(message1));
+        messageIds.push(computeMessageId(message2));
+        messageIds.push(computeMessageId(messageWithAmount));
+        messageIds.push(computeMessageId(messageBadSender));
+        messageIds.push(computeMessageId(messageBadRecipient));
+        messageIds.push(computeMessageId(messageBadData));
+        messageIds.push(computeMessageId(messageEOA));
+        messageIds.push(computeMessageId(messageEOANoAmount));
+        messageIds.push(computeMessageId(messageReentrant1));
+        messageIds.push(computeMessageId(messageReentrant2));
+
+        // create blocks
+        for (let i = 0; i < 500; i++) {
+            const blockHeader = createBlock(blockIds, messageIds);
+            const blockId = computeBlockId(blockHeader);
+            const blockSignature = await compactSign(env.poaSigner, blockId);
+
+            // append block header and Id to arrays
+            blockHeaders.push(blockHeader);
+            blockIds.push(blockId);
+            blockSignatures.push(blockSignature);
+        }
+
+        // make sure the portal has eth to relay
+        await env.fuelMessagePortal.depositETH(EMPTY, {
+            value: ethers.utils.parseEther('0.2'),
+        });
+
+        // Verify contract getters
+        expect(await env.fuelMessagePortal.sidechainConsensusContract()).to.equal(env.fuelSidechain.address);
+        expect(await messageTester.fuelMessagePortal()).to.equal(env.fuelMessagePortal.address);
+    });
+
+    describe('Verify access control', async () => {
+        const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
+        let signer0: string;
+        let signer1: string;
+        let signer2: string;
+        before(async () => {
+            signer0 = env.addresses[0];
+            signer1 = env.addresses[1];
+            signer2 = env.addresses[2];
+        });
+
+        it('Should be able to grant admin role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
+
+            // Grant admin role
+            await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
+        });
+
+        it('Should be able to renounce admin role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
+
+            // Revoke admin role
+            await expect(env.fuelMessagePortal.renounceRole(defaultAdminRole, signer0)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+        });
+
+        it('Should not be able to grant admin role as non-admin', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+
+            // Attempt grant admin role
+            await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer0)).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[0].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+        });
+
+        it('Should be able to grant then revoke admin role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
+
+            // Grant admin role
+            await expect(env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer0)).to.not.be
+                .reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
+
+            // Revoke previous admin
+            await expect(env.fuelMessagePortal.revokeRole(defaultAdminRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
+        });
+
+        it('Should be able to grant pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
+
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.grantRole(pauserRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
+        });
+
+        it('Should not be able to grant permission as pauser', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
+
+            // Attempt grant admin role
+            await expect(
+                env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer2)
+            ).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
+
+            // Attempt grant pauser role
+            await expect(
+                env.fuelMessagePortal.connect(env.signers[1]).grantRole(pauserRole, signer2)
+            ).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
+        });
+
+        it('Should be able to revoke pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
+
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.revokeRole(pauserRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
+        });
+    });
+
+    describe('Verify admin functions', async () => {
+        const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        let messageNodes: TreeNode[];
+        let blockHeader: BlockHeader;
+        let poaSignature: string;
+        before(async () => {
+            messageNodes = constructTree(messageIds);
+            blockHeader = blockHeaders[0];
+            poaSignature = blockSignatures[0];
+        });
+
+        it('Should not be able to set timelock as non-admin', async () => {
+            expect(await env.fuelMessagePortal.incomingMessageTimelock()).to.be.equal(BN.from(0));
+
+            // Attempt set timelock
+            await expect(
+                env.fuelMessagePortal.connect(env.signers[1]).setIncomingMessageTimelock(10)
+            ).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.incomingMessageTimelock()).to.be.equal(BN.from(0));
+        });
+
+        it('Should be able to set the timelock as admin', async () => {
+            const newTimelockValue = 7 * 24 * 60 * 60 * 1000;
+            expect(await env.fuelMessagePortal.incomingMessageTimelock()).to.not.be.equal(BN.from(newTimelockValue));
+
+            // Set timelock
+            await expect(env.fuelMessagePortal.setIncomingMessageTimelock(newTimelockValue)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageTimelock()).to.be.equal(BN.from(newTimelockValue));
+        });
+
+        it('Should not be able to relay valid message before timelock', async () => {
+            const messageID = computeMessageId(message1);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    message1,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Timelock not elapsed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+
+            // Remove timelock
+            await expect(env.fuelMessagePortal.setIncomingMessageTimelock(0)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageTimelock()).to.be.equal(BN.from(0));
+        });
+
+        it('Should not get a valid message sender outside of relaying', async () => {
+            await expect(env.fuelMessagePortal.messageSender()).to.be.revertedWith('Current message sender not set');
+        });
+    });
+
+    describe('Relay both valid and invalid messages', async () => {
+        let provider: Provider;
+        let prevBlockNodes: TreeNode[];
+        let messageNodes: TreeNode[];
+        let blockHeader: BlockHeader;
+        let poaSignature: string;
+        let prevRootHeader: BlockHeaderLite;
+        let prevRootPoaSignature: string;
+        before(async () => {
+            provider = env.fuelMessagePortal.provider;
+            messageNodes = constructTree(messageIds);
+            blockHeader = blockHeaders[0];
+            poaSignature = blockSignatures[0];
+
+            const prevBlockNodesRootBlockNum = blockIds.length - 1;
+            prevRootHeader = generateBlockHeaderLite(blockHeaders[prevBlockNodesRootBlockNum]);
+            prevRootPoaSignature = blockSignatures[prevBlockNodesRootBlockNum];
+            const prevBlockIds = [];
+            for (let i = 0; i < blockIds.length - 1; i++) prevBlockIds.push(blockIds[i]);
+            prevBlockNodes = constructTree(prevBlockIds);
+        });
+
+        it('Should not be able to call messageable contract directly', async () => {
+            await expect(messageTester.receiveMessage(messageTestData3, messageTestData3)).to.be.revertedWith(
+                'Caller is not the portal'
+            );
+        });
+
+        it('Should not be able to relay message with bad block', async () => {
+            const messageID = computeMessageId(message1);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    message1,
+                    blockHeader,
+                    messageInBlockProof,
+                    randomBytes32()
+                )
+            ).to.be.revertedWith('signature-invalid-length');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should not be able to relay message with bad root block', async () => {
+            const messageBlockNum = 258;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(message1);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    message1,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    randomBytes32()
+                )
+            ).to.be.revertedWith('signature-invalid-length');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should not be able to relay message with bad proof in root block', async () => {
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            const messageTesterBalance = await provider.getBalance(messageTester.address);
+            const messageBlockNum = 67;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum + 1]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(message1);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    message1,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Invalid block in history proof');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
+            expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
+        });
+
+        it('Should not be able to relay reentrant messages', async () => {
+            const messageBlockNum = 145;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+
+            // re-enter via relayMessageFromFuelBlock
+            const messageID = computeMessageId(messageReentrant1);
+            const messageLeafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: messageLeafIndexKey,
+                proof: getProof(messageNodes, messageLeafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageReentrant1,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+
+            // re-enter via relayMessageFromPrevFuelBlock
+            const messageID2 = computeMessageId(messageReentrant2);
+            const messageLeafIndexKey2 = getLeafIndexKey(messageNodes, messageID2);
+            const messageInBlockProof2 = {
+                key: messageLeafIndexKey2,
+                proof: getProof(messageNodes, messageLeafIndexKey2),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageReentrant2,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof2,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should be able to relay valid message', async () => {
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            const messageTesterBalance = await provider.getBalance(messageTester.address);
+            const messageBlockNum = 145;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(message1);
+            const messageLeafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: messageLeafIndexKey,
+                proof: getProof(messageNodes, messageLeafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    message1,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await messageTester.data1()).to.be.equal(messageTestData1);
+            expect(await messageTester.data2()).to.be.equal(messageTestData2);
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
+            expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
+        });
+
+        it('Should not be able to relay already relayed message', async () => {
+            const messageBlockNum = 68;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(message1);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    message1,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Already relayed');
+        });
+
+        it('Should not be able to relay message with low gas', async () => {
+            const messageBlockNum = 11;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(messageWithAmount);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            const options = {
+                gasLimit: 140000,
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageWithAmount,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature,
+                    options
+                )
+            ).to.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should be able to relay message with amount', async () => {
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            const messageTesterBalance = await provider.getBalance(messageTester.address);
+            const messageBlockNum = 333;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(messageWithAmount);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageWithAmount,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await messageTester.data1()).to.be.equal(messageTestData2);
+            expect(await messageTester.data2()).to.be.equal(messageTestData3);
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(
+                portalBalance.sub(messageWithAmount.amount.mul(baseAssetConversion))
+            );
+            expect(await provider.getBalance(messageTester.address)).to.be.equal(
+                messageTesterBalance.add(messageWithAmount.amount.mul(baseAssetConversion))
+            );
+        });
+
+        it('Should not be able to relay message from untrusted sender', async () => {
+            const messageBlockNum = 471;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(messageBadSender);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageBadSender,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should not be able to relay message to bad recipient', async () => {
+            const messageBlockNum = 296;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(messageBadRecipient);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageBadRecipient,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should not be able to relay message with bad data', async () => {
+            const messageBlockNum = 321;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(messageBadData);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageBadData,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Message relay failed');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should be able to relay message to EOA', async () => {
+            const accountBalance = await provider.getBalance(env.addresses[2]);
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            const messageBlockNum = 19;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(messageEOA);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageEOA,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await provider.getBalance(env.addresses[2])).to.be.equal(
+                accountBalance.add(messageEOA.amount.mul(baseAssetConversion))
+            );
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(
+                portalBalance.sub(messageEOA.amount.mul(baseAssetConversion))
+            );
+        });
+
+        it('Should be able to relay message to EOA with no amount', async () => {
+            const accountBalance = await provider.getBalance(env.addresses[3]);
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            const messageBlockNum = 25;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(messageEOANoAmount);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    messageEOANoAmount,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await provider.getBalance(env.addresses[3])).to.be.equal(accountBalance);
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
+        });
+
+        it('Should not be able to relay valid message with different amount', async () => {
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            const messageTesterBalance = await provider.getBalance(messageTester.address);
+            const messageBlockNum = 68;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(message2);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            const diffBlock = {
+                sender: message2.sender,
+                recipient: message2.recipient,
+                nonce: message2.nonce,
+                amount: message2.amount.add(ethers.utils.parseEther('1.0')),
+                data: message2.data,
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    diffBlock,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    prevRootPoaSignature
+                )
+            ).to.be.revertedWith('Invalid message in block proof');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
+            expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
+        });
+
+        it('Should not be able to relay non-existent message', async () => {
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            const messageTesterBalance = await provider.getBalance(messageTester.address);
+            const messageInBlockProof = {
+                key: 0,
+                proof: [],
+            };
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    message2,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Invalid message in block proof');
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.be.equal(portalBalance);
+            expect(await provider.getBalance(messageTester.address)).to.be.equal(messageTesterBalance);
+        });
+    });
+
+    describe('Verify pause and unpause', async () => {
+        const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
+        let messageNodes: TreeNode[];
+        let prevBlockNodes: TreeNode[];
+        let blockHeader: BlockHeader;
+        let prevRootHeader: BlockHeaderLite;
+        let poaSignature: string;
+        before(async () => {
+            messageNodes = constructTree(messageIds);
+            blockHeader = blockHeaders[0];
+            poaSignature = blockSignatures[0];
+            const prevBlockNodesRootBlockNum = blockIds.length - 1;
+            prevRootHeader = generateBlockHeaderLite(blockHeaders[prevBlockNodesRootBlockNum]);
+            const prevBlockIds = [];
+            for (let i = 0; i < blockIds.length - 1; i++) prevBlockIds.push(blockIds[i]);
+            prevBlockNodes = constructTree(prevBlockIds);
+        });
+
+        it('Should be able to grant pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
+
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.grantRole(pauserRole, env.addresses[2])).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
+        });
+
+        it('Should not be able to pause as non-pauser', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+
+            // Attempt pause
+            await expect(env.fuelMessagePortal.connect(env.signers[1]).pause()).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${pauserRole}`
+            );
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+        });
+
+        it('Should be able to pause as pauser', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+
+            // Pause
+            await expect(env.fuelMessagePortal.connect(env.signers[2]).pause()).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+        });
+
+        it('Should not be able to unpause as pauser (and not admin)', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+
+            // Attempt unpause
+            await expect(env.fuelMessagePortal.connect(env.signers[2]).unpause()).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[2].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+        });
+
+        it('Should not be able to unpause as non-admin', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+
+            // Attempt unpause
+            await expect(env.fuelMessagePortal.connect(env.signers[1]).unpause()).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+        });
+
+        it('Should not be able to relay messages when paused', async () => {
+            const messageBlockNum = 258;
+            const messageBlockLeafIndexKey = getLeafIndexKey(prevBlockNodes, blockIds[messageBlockNum]);
+            const blockInHistoryProof = {
+                key: messageBlockLeafIndexKey,
+                proof: getProof(prevBlockNodes, messageBlockLeafIndexKey),
+            };
+            const messageID = computeMessageId(message2);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    message2,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.be.revertedWith('Pausable: paused');
+            await expect(
+                env.fuelMessagePortal.relayMessageFromPrevFuelBlock(
+                    message2,
+                    prevRootHeader,
+                    blockHeaders[messageBlockNum],
+                    blockInHistoryProof,
+                    messageInBlockProof,
+                    randomBytes32()
+                )
+            ).to.be.revertedWith('Pausable: paused');
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+        });
+
+        it('Should be able to unpause as admin', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+
+            // Unpause
+            await expect(env.fuelMessagePortal.unpause()).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+        });
+
+        it('Should be able to relay message when unpaused', async () => {
+            const messageID = computeMessageId(message2);
+            const leafIndexKey = getLeafIndexKey(messageNodes, messageID);
+            const messageInBlockProof = {
+                key: leafIndexKey,
+                proof: getProof(messageNodes, leafIndexKey),
+            };
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(false);
+            await expect(
+                env.fuelMessagePortal.relayMessageFromFuelBlock(
+                    message2,
+                    blockHeader,
+                    messageInBlockProof,
+                    poaSignature
+                )
+            ).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.incomingMessageSuccessful(messageID)).to.be.equal(true);
+            expect(await messageTester.data1()).to.be.equal(messageTestData2);
+            expect(await messageTester.data2()).to.be.equal(messageTestData1);
+        });
+
+        it('Should be able to revoke pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
+
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.revokeRole(pauserRole, env.addresses[2])).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
+        });
+    });
 });

--- a/test/messagesOutgoing.ts
+++ b/test/messagesOutgoing.ts
@@ -11,360 +11,362 @@ chai.use(solidity);
 const { expect } = chai;
 
 describe('Outgoing Messages', async () => {
-	let env: HarnessObject;
+    let env: HarnessObject;
+    const nonceList: string[] = [];
 
-	// Testing contracts
-	let messageTester: MessageTester;
+    // Testing contracts
+    let messageTester: MessageTester;
 
-	before(async () => {
-		env = await setupFuel();
+    before(async () => {
+        env = await setupFuel();
 
-		// Deploy contracts for message testing
-		const messageTesterContractFactory = await ethers.getContractFactory('MessageTester');
-		messageTester = (await messageTesterContractFactory.deploy(env.fuelMessagePortal.address)) as MessageTester;
-		await messageTester.deployed();
+        // Deploy contracts for message testing
+        const messageTesterContractFactory = await ethers.getContractFactory('MessageTester');
+        messageTester = (await messageTesterContractFactory.deploy(env.fuelMessagePortal.address)) as MessageTester;
+        await messageTester.deployed();
 
-		// Send eth to contract
-		const tx = {
-			to: messageTester.address,
-			value: ethers.utils.parseEther('2'),
-		};
-		const transaction = await env.signers[0].sendTransaction(tx);
-		await transaction.wait();
-	});
+        // Send eth to contract
+        const tx = {
+            to: messageTester.address,
+            value: ethers.utils.parseEther('2'),
+        };
+        const transaction = await env.signers[0].sendTransaction(tx);
+        await transaction.wait();
 
-	describe('Verify access control', async () => {
-		const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
-		const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
-		let signer0: string;
-		let signer1: string;
-		let signer2: string;
-		before(async () => {
-			signer0 = env.addresses[0];
-			signer1 = env.addresses[1];
-			signer2 = env.addresses[2];
-		});
+        // Verify contract getters
+        expect(await env.fuelMessagePortal.sidechainConsensusContract()).to.equal(env.fuelSidechain.address);
+        expect(await messageTester.fuelMessagePortal()).to.equal(env.fuelMessagePortal.address);
+    });
 
-		it('Should be able to grant admin role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
+    describe('Verify access control', async () => {
+        const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
+        let signer0: string;
+        let signer1: string;
+        let signer2: string;
+        before(async () => {
+            signer0 = env.addresses[0];
+            signer1 = env.addresses[1];
+            signer2 = env.addresses[2];
+        });
 
-			// Grant admin role
-			await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
-		});
+        it('Should be able to grant admin role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
 
-		it('Should be able to renounce admin role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
+            // Grant admin role
+            await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
+        });
 
-			// Revoke admin role
-			await expect(env.fuelMessagePortal.renounceRole(defaultAdminRole, signer0)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
-		});
+        it('Should be able to renounce admin role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
 
-		it('Should not be able to grant admin role as non-admin', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+            // Revoke admin role
+            await expect(env.fuelMessagePortal.renounceRole(defaultAdminRole, signer0)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+        });
 
-			// Attempt grant admin role
-			await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer0)).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[0].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
-		});
+        it('Should not be able to grant admin role as non-admin', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
 
-		it('Should be able to grant then revoke admin role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
+            // Attempt grant admin role
+            await expect(env.fuelMessagePortal.grantRole(defaultAdminRole, signer0)).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[0].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+        });
 
-			// Grant admin role
-			await expect(env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer0)).to.not.be
-				.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
+        it('Should be able to grant then revoke admin role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(false);
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(true);
 
-			// Revoke previous admin
-			await expect(env.fuelMessagePortal.revokeRole(defaultAdminRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
-		});
+            // Grant admin role
+            await expect(env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer0)).to.not.be
+                .reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer0)).to.equal(true);
 
-		it('Should be able to grant pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
+            // Revoke previous admin
+            await expect(env.fuelMessagePortal.revokeRole(defaultAdminRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer1)).to.equal(false);
+        });
 
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.grantRole(pauserRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
-		});
+        it('Should be able to grant pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
 
-		it('Should not be able to grant permission as pauser', async () => {
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.grantRole(pauserRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
+        });
 
-			// Attempt grant admin role
-			await expect(
-				env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer2)
-			).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
+        it('Should not be able to grant permission as pauser', async () => {
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
 
-			// Attempt grant pauser role
-			await expect(
-				env.fuelMessagePortal.connect(env.signers[1]).grantRole(pauserRole, signer2)
-			).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
-		});
+            // Attempt grant admin role
+            await expect(
+                env.fuelMessagePortal.connect(env.signers[1]).grantRole(defaultAdminRole, signer2)
+            ).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.hasRole(defaultAdminRole, signer2)).to.equal(false);
 
-		it('Should be able to revoke pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
+            // Attempt grant pauser role
+            await expect(
+                env.fuelMessagePortal.connect(env.signers[1]).grantRole(pauserRole, signer2)
+            ).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer2)).to.equal(false);
+        });
 
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.revokeRole(pauserRole, signer1)).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
-		});
-	});
+        it('Should be able to revoke pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(true);
 
-	describe('Send messages', async () => {
-		let provider: Provider;
-		let filterAddress: string;
-		let fuelBaseAssetDecimals: number;
-		let baseAssetConversion: number;
-		before(async () => {
-			provider = env.fuelMessagePortal.provider;
-			filterAddress = env.fuelMessagePortal.address;
-			fuelBaseAssetDecimals = await env.fuelMessagePortal.getFuelBaseAssetDecimals();
-			baseAssetConversion = 10 ** (18 - fuelBaseAssetDecimals);
-		});
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.revokeRole(pauserRole, signer1)).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, signer1)).to.equal(false);
+        });
+    });
 
-		it('Should be able to send message with data', async () => {
-			const recipient = randomBytes32();
-			const data = randomBytes(16);
-			const nonce = await env.fuelMessagePortal.s_outgoingMessageNonce();
-			await expect(messageTester.attemptSendMessage(recipient, data)).to.not.be.reverted;
+    describe('Send messages', async () => {
+        let provider: Provider;
+        let filterAddress: string;
+        let fuelBaseAssetDecimals: number;
+        let baseAssetConversion: number;
+        before(async () => {
+            provider = env.fuelMessagePortal.provider;
+            filterAddress = env.fuelMessagePortal.address;
+            fuelBaseAssetDecimals = await env.fuelMessagePortal.fuelBaseAssetDecimals();
+            baseAssetConversion = 10 ** (18 - fuelBaseAssetDecimals);
+        });
 
-			// Check logs for message sent
-			const logs = await provider.getLogs({ address: filterAddress });
-			const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
-			expect(sentMessageEvent.name).to.equal('SentMessage');
-			expect(sentMessageEvent.args.sender).to.equal(
-				messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
-			);
-			expect(sentMessageEvent.args.recipient).to.equal(recipient);
-			expect(sentMessageEvent.args.data).to.equal(data);
-			expect(sentMessageEvent.args.amount).to.equal(0);
-			expect(sentMessageEvent.args.nonce).to.equal(nonce);
+        it('Should be able to send message with data', async () => {
+            const recipient = randomBytes32();
+            const data = randomBytes(16);
+            await expect(messageTester.attemptSendMessage(recipient, data)).to.not.be.reverted;
 
-			// Check that nonce increased
-			expect(await env.fuelMessagePortal.s_outgoingMessageNonce()).to.not.equal(nonce);
-		});
+            // Check logs for message sent
+            const logs = await provider.getLogs({ address: filterAddress });
+            const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
+            expect(sentMessageEvent.name).to.equal('SentMessage');
+            expect(sentMessageEvent.args.sender).to.equal(
+                messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
+            );
+            expect(sentMessageEvent.args.recipient).to.equal(recipient);
+            expect(sentMessageEvent.args.data).to.equal(data);
+            expect(sentMessageEvent.args.amount).to.equal(0);
 
-		it('Should be able to send message without data', async () => {
-			const recipient = randomBytes32();
-			const nonce = await env.fuelMessagePortal.s_outgoingMessageNonce();
-			await expect(messageTester.attemptSendMessage(recipient, [])).to.not.be.reverted;
+            // Check that nonce is unique
+            expect(nonceList).to.not.include(sentMessageEvent.args.nonce);
+            nonceList.push(sentMessageEvent.args.nonce);
+        });
 
-			// Check logs for message sent
-			const logs = await provider.getLogs({ address: filterAddress });
-			const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
-			expect(sentMessageEvent.name).to.equal('SentMessage');
-			expect(sentMessageEvent.args.sender).to.equal(
-				messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
-			);
-			expect(sentMessageEvent.args.recipient).to.equal(recipient);
-			expect(sentMessageEvent.args.data).to.equal('0x');
-			expect(sentMessageEvent.args.amount).to.equal(0);
-			expect(sentMessageEvent.args.nonce).to.equal(nonce);
+        it('Should be able to send message without data', async () => {
+            const recipient = randomBytes32();
+            await expect(messageTester.attemptSendMessage(recipient, [])).to.not.be.reverted;
 
-			// Check that nonce increased
-			expect(await env.fuelMessagePortal.s_outgoingMessageNonce()).to.not.equal(nonce);
-		});
+            // Check logs for message sent
+            const logs = await provider.getLogs({ address: filterAddress });
+            const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
+            expect(sentMessageEvent.name).to.equal('SentMessage');
+            expect(sentMessageEvent.args.sender).to.equal(
+                messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
+            );
+            expect(sentMessageEvent.args.recipient).to.equal(recipient);
+            expect(sentMessageEvent.args.data).to.equal('0x');
+            expect(sentMessageEvent.args.amount).to.equal(0);
 
-		it('Should be able to send message with amount and data', async () => {
-			const recipient = randomBytes32();
-			const data = randomBytes(8);
-			const nonce = await env.fuelMessagePortal.s_outgoingMessageNonce();
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			await expect(messageTester.attemptSendMessageWithAmount(recipient, ethers.utils.parseEther('0.1'), data)).to
-				.not.be.reverted;
+            // Check that nonce is unique
+            expect(nonceList).to.not.include(sentMessageEvent.args.nonce);
+            nonceList.push(sentMessageEvent.args.nonce);
+        });
 
-			// Check logs for message sent
-			const logs = await provider.getLogs({ address: filterAddress });
-			const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
-			expect(sentMessageEvent.name).to.equal('SentMessage');
-			expect(sentMessageEvent.args.sender).to.equal(
-				messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
-			);
-			expect(sentMessageEvent.args.recipient).to.equal(recipient);
-			expect(sentMessageEvent.args.data).to.equal(data);
-			expect(sentMessageEvent.args.amount).to.equal(ethers.utils.parseEther('0.1').div(baseAssetConversion));
-			expect(sentMessageEvent.args.nonce).to.equal(nonce);
+        it('Should be able to send message with amount and data', async () => {
+            const recipient = randomBytes32();
+            const data = randomBytes(8);
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            await expect(messageTester.attemptSendMessageWithAmount(recipient, ethers.utils.parseEther('0.1'), data)).to
+                .not.be.reverted;
 
-			// Check that nonce increased
-			expect(await env.fuelMessagePortal.s_outgoingMessageNonce()).to.not.equal(nonce);
+            // Check logs for message sent
+            const logs = await provider.getLogs({ address: filterAddress });
+            const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
+            expect(sentMessageEvent.name).to.equal('SentMessage');
+            expect(sentMessageEvent.args.sender).to.equal(
+                messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
+            );
+            expect(sentMessageEvent.args.recipient).to.equal(recipient);
+            expect(sentMessageEvent.args.data).to.equal(data);
+            expect(sentMessageEvent.args.amount).to.equal(ethers.utils.parseEther('0.1').div(baseAssetConversion));
 
-			// Check that portal balance increased
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.equal(
-				portalBalance.add(ethers.utils.parseEther('0.1'))
-			);
-		});
+            // Check that nonce is unique
+            expect(nonceList).to.not.include(sentMessageEvent.args.nonce);
+            nonceList.push(sentMessageEvent.args.nonce);
 
-		it('Should be able to send message with amount and without data', async () => {
-			const recipient = randomBytes32();
-			const nonce = await env.fuelMessagePortal.s_outgoingMessageNonce();
-			const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
-			await expect(messageTester.attemptSendMessageWithAmount(recipient, ethers.utils.parseEther('0.5'), [])).to
-				.not.be.reverted;
+            // Check that portal balance increased
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.equal(
+                portalBalance.add(ethers.utils.parseEther('0.1'))
+            );
+        });
 
-			// Check logs for message sent
-			const logs = await provider.getLogs({ address: filterAddress });
-			const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
-			expect(sentMessageEvent.name).to.equal('SentMessage');
-			expect(sentMessageEvent.args.sender).to.equal(
-				messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
-			);
-			expect(sentMessageEvent.args.recipient).to.equal(recipient);
-			expect(sentMessageEvent.args.data).to.equal('0x');
-			expect(sentMessageEvent.args.amount).to.equal(ethers.utils.parseEther('0.5').div(baseAssetConversion));
-			expect(sentMessageEvent.args.nonce).to.equal(nonce);
+        it('Should be able to send message with amount and without data', async () => {
+            const recipient = randomBytes32();
+            const portalBalance = await provider.getBalance(env.fuelMessagePortal.address);
+            await expect(messageTester.attemptSendMessageWithAmount(recipient, ethers.utils.parseEther('0.5'), [])).to
+                .not.be.reverted;
 
-			// Check that nonce increased
-			expect(await env.fuelMessagePortal.s_outgoingMessageNonce()).to.not.equal(nonce);
+            // Check logs for message sent
+            const logs = await provider.getLogs({ address: filterAddress });
+            const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
+            expect(sentMessageEvent.name).to.equal('SentMessage');
+            expect(sentMessageEvent.args.sender).to.equal(
+                messageTester.address.split('0x').join('0x000000000000000000000000').toLowerCase()
+            );
+            expect(sentMessageEvent.args.recipient).to.equal(recipient);
+            expect(sentMessageEvent.args.data).to.equal('0x');
+            expect(sentMessageEvent.args.amount).to.equal(ethers.utils.parseEther('0.5').div(baseAssetConversion));
 
-			// Check that portal balance increased
-			expect(await provider.getBalance(env.fuelMessagePortal.address)).to.equal(
-				portalBalance.add(ethers.utils.parseEther('0.5'))
-			);
-		});
+            // Check that nonce is unique
+            expect(nonceList).to.not.include(sentMessageEvent.args.nonce);
+            nonceList.push(sentMessageEvent.args.nonce);
 
-		it('Should not be able to send message with amount too small', async () => {
-			const recipient = randomBytes32();
-			await expect(
-				env.fuelMessagePortal.sendMessage(recipient, [], {
-					value: 1,
-				})
-			).to.be.revertedWith('amount-precision-incompatability');
-		});
+            // Check that portal balance increased
+            expect(await provider.getBalance(env.fuelMessagePortal.address)).to.equal(
+                portalBalance.add(ethers.utils.parseEther('0.5'))
+            );
+        });
 
-		it('Should not be able to send message with amount too big', async () => {
-			const recipient = randomBytes32();
-			await ethers.provider.send('hardhat_setBalance', [env.addresses[0], '0xf00000000000000000000000']);
-			await expect(
-				env.fuelMessagePortal.sendMessage(recipient, [], {
-					value: BN.from('0x3b9aca000000000000000000'),
-				})
-			).to.be.revertedWith('amount-precision-incompatability');
-		});
+        it('Should not be able to send message with amount too small', async () => {
+            const recipient = randomBytes32();
+            await expect(
+                env.fuelMessagePortal.sendMessage(recipient, [], {
+                    value: 1,
+                })
+            ).to.be.revertedWith('amount-precision-incompatability');
+        });
 
-		it('Should not be able to send message with too much data', async () => {
-			const recipient = randomBytes32();
-			const data = new Uint8Array(65536 + 1);
-			await expect(env.fuelMessagePortal.sendMessage(recipient, data)).to.be.revertedWith(
-				'message-data-too-large'
-			);
-		});
+        it('Should not be able to send message with amount too big', async () => {
+            const recipient = randomBytes32();
+            await ethers.provider.send('hardhat_setBalance', [env.addresses[0], '0xf00000000000000000000000']);
+            await expect(
+                env.fuelMessagePortal.sendMessage(recipient, [], {
+                    value: BN.from('0x3b9aca000000000000000000'),
+                })
+            ).to.be.revertedWith('amount-precision-incompatability');
+        });
 
-		it('Should be able to send message with only ETH', async () => {
-			const recipient = randomBytes32();
-			const nonce = await env.fuelMessagePortal.s_outgoingMessageNonce();
-			await expect(
-				env.fuelMessagePortal.sendETH(recipient, {
-					value: ethers.utils.parseEther('1.234'),
-				})
-			).to.not.be.reverted;
+        it('Should not be able to send message with too much data', async () => {
+            const recipient = randomBytes32();
+            const data = new Uint8Array(65536 + 1);
+            await expect(env.fuelMessagePortal.sendMessage(recipient, data)).to.be.revertedWith(
+                'message-data-too-large'
+            );
+        });
 
-			// Check logs for message sent
-			const logs = await provider.getLogs({ address: filterAddress });
-			const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
-			expect(sentMessageEvent.name).to.equal('SentMessage');
-			expect(sentMessageEvent.args.sender).to.equal(
-				env.addresses[0].split('0x').join('0x000000000000000000000000').toLowerCase()
-			);
-			expect(sentMessageEvent.args.recipient).to.equal(recipient);
-			expect(sentMessageEvent.args.data).to.equal('0x');
-			expect(sentMessageEvent.args.amount).to.equal(ethers.utils.parseEther('1.234').div(baseAssetConversion));
-			expect(sentMessageEvent.args.nonce).to.equal(nonce);
+        it('Should be able to send message with only ETH', async () => {
+            const recipient = randomBytes32();
+            await expect(
+                env.fuelMessagePortal.depositETH(recipient, {
+                    value: ethers.utils.parseEther('1.234'),
+                })
+            ).to.not.be.reverted;
 
-			// Check that nonce increased
-			expect(await env.fuelMessagePortal.s_outgoingMessageNonce()).to.not.equal(nonce);
-		});
-	});
+            // Check logs for message sent
+            const logs = await provider.getLogs({ address: filterAddress });
+            const sentMessageEvent = env.fuelMessagePortal.interface.parseLog(logs[logs.length - 1]);
+            expect(sentMessageEvent.name).to.equal('SentMessage');
+            expect(sentMessageEvent.args.sender).to.equal(
+                env.addresses[0].split('0x').join('0x000000000000000000000000').toLowerCase()
+            );
+            expect(sentMessageEvent.args.recipient).to.equal(recipient);
+            expect(sentMessageEvent.args.data).to.equal('0x');
+            expect(sentMessageEvent.args.amount).to.equal(ethers.utils.parseEther('1.234').div(baseAssetConversion));
 
-	describe('Verify pause and unpause', async () => {
-		const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
-		const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
-		const recipient = randomBytes32();
-		const data = randomBytes(8);
+            // Check that nonce is unique
+            expect(nonceList).to.not.include(sentMessageEvent.args.nonce);
+            nonceList.push(sentMessageEvent.args.nonce);
+        });
+    });
 
-		it('Should be able to grant pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
+    describe('Verify pause and unpause', async () => {
+        const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const pauserRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('PAUSER_ROLE'));
+        const recipient = randomBytes32();
+        const data = randomBytes(8);
 
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.grantRole(pauserRole, env.addresses[2])).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
-		});
+        it('Should be able to grant pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
 
-		it('Should not be able to pause as non-pauser', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.grantRole(pauserRole, env.addresses[2])).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
+        });
 
-			// Attempt pause
-			await expect(env.fuelMessagePortal.connect(env.signers[1]).pause()).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${pauserRole}`
-			);
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
-		});
+        it('Should not be able to pause as non-pauser', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
 
-		it('Should be able to pause as pauser', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+            // Attempt pause
+            await expect(env.fuelMessagePortal.connect(env.signers[1]).pause()).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${pauserRole}`
+            );
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+        });
 
-			// Pause
-			await expect(env.fuelMessagePortal.connect(env.signers[2]).pause()).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-		});
+        it('Should be able to pause as pauser', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
 
-		it('Should not be able to unpause as pauser (and not admin)', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+            // Pause
+            await expect(env.fuelMessagePortal.connect(env.signers[2]).pause()).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+        });
 
-			// Attempt unpause
-			await expect(env.fuelMessagePortal.connect(env.signers[2]).unpause()).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[2].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-		});
+        it('Should not be able to unpause as pauser (and not admin)', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
 
-		it('Should not be able to unpause as non-admin', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+            // Attempt unpause
+            await expect(env.fuelMessagePortal.connect(env.signers[2]).unpause()).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[2].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+        });
 
-			// Attempt unpause
-			await expect(env.fuelMessagePortal.connect(env.signers[1]).unpause()).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-		});
+        it('Should not be able to unpause as non-admin', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
 
-		it('Should not be able to send messages when paused', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
-			await expect(env.fuelMessagePortal.sendMessage(recipient, data)).to.be.revertedWith('Pausable: paused');
-			await expect(env.fuelMessagePortal.sendETH(recipient, { value: 1 })).to.be.revertedWith('Pausable: paused');
-		});
+            // Attempt unpause
+            await expect(env.fuelMessagePortal.connect(env.signers[1]).unpause()).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+        });
 
-		it('Should be able to unpause as admin', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+        it('Should not be able to send messages when paused', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
+            await expect(env.fuelMessagePortal.sendMessage(recipient, data)).to.be.revertedWith('Pausable: paused');
+            await expect(env.fuelMessagePortal.depositETH(recipient, { value: 1 })).to.be.revertedWith(
+                'Pausable: paused'
+            );
+        });
 
-			// Unpause
-			await expect(env.fuelMessagePortal.unpause()).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
-		});
+        it('Should be able to unpause as admin', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(true);
 
-		it('Should be able to send messages when unpaused', async () => {
-			expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
-			await expect(env.fuelMessagePortal.sendMessage(recipient, data)).to.not.be.reverted;
-		});
+            // Unpause
+            await expect(env.fuelMessagePortal.unpause()).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+        });
 
-		it('Should be able to revoke pauser role', async () => {
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
+        it('Should be able to send messages when unpaused', async () => {
+            expect(await env.fuelMessagePortal.paused()).to.be.equal(false);
+            await expect(env.fuelMessagePortal.sendMessage(recipient, data)).to.not.be.reverted;
+        });
 
-			// Grant pauser role
-			await expect(env.fuelMessagePortal.revokeRole(pauserRole, env.addresses[2])).to.not.be.reverted;
-			expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
-		});
-	});
+        it('Should be able to revoke pauser role', async () => {
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(true);
+
+            // Grant pauser role
+            await expect(env.fuelMessagePortal.revokeRole(pauserRole, env.addresses[2])).to.not.be.reverted;
+            expect(await env.fuelMessagePortal.hasRole(pauserRole, env.addresses[2])).to.equal(false);
+        });
+    });
 });

--- a/test/upgrade.ts
+++ b/test/upgrade.ts
@@ -8,67 +8,67 @@ chai.use(solidity);
 const { expect } = chai;
 
 describe('Contract Upgradability', async () => {
-	let env: HarnessObject;
-	let upgradeableTester: UpgradeableTester;
+    let env: HarnessObject;
+    let upgradeableTester: UpgradeableTester;
 
-	before(async () => {
-		env = await setupFuel();
+    before(async () => {
+        env = await setupFuel();
 
-		// Deploy contracts for abstract upgradeable contract testing.
-		const upgradeableTesterContractFactory = await ethers.getContractFactory('UpgradeableTester');
-		upgradeableTester = (await upgradeableTesterContractFactory.deploy()) as UpgradeableTester;
-		await upgradeableTester.deployed();
-	});
+        // Deploy contracts for abstract upgradeable contract testing.
+        const upgradeableTesterContractFactory = await ethers.getContractFactory('UpgradeableTester');
+        upgradeableTester = (await upgradeableTesterContractFactory.deploy()) as UpgradeableTester;
+        await upgradeableTester.deployed();
+    });
 
-	describe('Upgrade contracts', async () => {
-		const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
-		it('Should be able to upgrade contracts', async () => {
-			const contracts = {
-				FuelSidechainConsensus: env.fuelSidechain.address,
-				FuelMessagePortal: env.fuelMessagePortal.address,
-				L1ERC20Gateway: env.l1ERC20Gateway.address,
-				FuelSidechainConsensus_impl: '',
-				FuelMessagePortal_impl: '',
-				L1ERC20Gateway_impl: '',
-			};
-			const upgradedContracts = await upgradeFuel(contracts);
+    describe('Upgrade contracts', async () => {
+        const defaultAdminRole = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        it('Should be able to upgrade contracts', async () => {
+            const contracts = {
+                FuelSidechainConsensus: env.fuelSidechain.address,
+                FuelMessagePortal: env.fuelMessagePortal.address,
+                FuelERC20Gateway: env.fuelERC20Gateway.address,
+                FuelSidechainConsensus_impl: '',
+                FuelMessagePortal_impl: '',
+                FuelERC20Gateway_impl: '',
+            };
+            const upgradedContracts = await upgradeFuel(contracts);
 
-			expect(upgradedContracts.FuelSidechainConsensus).to.equal(env.fuelSidechain.address);
-			expect(upgradedContracts.FuelMessagePortal).to.equal(env.fuelMessagePortal.address);
-			expect(upgradedContracts.L1ERC20Gateway).to.equal(env.l1ERC20Gateway.address);
-		});
+            expect(upgradedContracts.FuelSidechainConsensus).to.equal(env.fuelSidechain.address);
+            expect(upgradedContracts.FuelMessagePortal).to.equal(env.fuelMessagePortal.address);
+            expect(upgradedContracts.FuelERC20Gateway).to.equal(env.fuelERC20Gateway.address);
+        });
 
-		it('Should not be able to call initializers', async () => {
-			await expect(env.fuelSidechain.initialize(env.signer)).to.be.revertedWith(
-				'Initializable: contract is already initialized'
-			);
-			await expect(env.fuelMessagePortal.initialize(env.fuelSidechain.address)).to.be.revertedWith(
-				'Initializable: contract is already initialized'
-			);
-			await expect(env.l1ERC20Gateway.initialize(env.fuelMessagePortal.address)).to.be.revertedWith(
-				'Initializable: contract is already initialized'
-			);
-		});
+        it('Should not be able to call initializers', async () => {
+            await expect(env.fuelSidechain.initialize(env.signer)).to.be.revertedWith(
+                'Initializable: contract is already initialized'
+            );
+            await expect(env.fuelMessagePortal.initialize(env.fuelSidechain.address)).to.be.revertedWith(
+                'Initializable: contract is already initialized'
+            );
+            await expect(env.fuelERC20Gateway.initialize(env.fuelMessagePortal.address)).to.be.revertedWith(
+                'Initializable: contract is already initialized'
+            );
+        });
 
-		it('Should not be able to call init functions for upgradeable abstract contracts', async () => {
-			await expect(
-				upgradeableTester.testFuelMessagesEnabledInit(env.fuelMessagePortal.address)
-			).to.be.revertedWith('Initializable: contract is not initializing');
-			await expect(
-				upgradeableTester.testFuelMessagesEnabledInitUnchained(env.fuelMessagePortal.address)
-			).to.be.revertedWith('Initializable: contract is not initializing');
-		});
+        it('Should not be able to call init functions for upgradeable abstract contracts', async () => {
+            await expect(
+                upgradeableTester.testFuelMessagesEnabledInit(env.fuelMessagePortal.address)
+            ).to.be.revertedWith('Initializable: contract is not initializing');
+            await expect(
+                upgradeableTester.testFuelMessagesEnabledInitUnchained(env.fuelMessagePortal.address)
+            ).to.be.revertedWith('Initializable: contract is not initializing');
+        });
 
-		it('Should not be able to upgrade contracts as non-admin', async () => {
-			await expect(env.fuelSidechain.connect(env.signers[1]).upgradeTo(env.addresses[1])).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-			await expect(env.fuelMessagePortal.connect(env.signers[1]).upgradeTo(env.addresses[1])).to.be.revertedWith(
-				`AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
-			);
-			await expect(env.l1ERC20Gateway.connect(env.signers[1]).upgradeTo(env.addresses[1])).to.be.revertedWith(
-				'Ownable: caller is not the owner'
-			);
-		});
-	});
+        it('Should not be able to upgrade contracts as non-admin', async () => {
+            await expect(env.fuelSidechain.connect(env.signers[1]).upgradeTo(env.addresses[1])).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+            await expect(env.fuelMessagePortal.connect(env.signers[1]).upgradeTo(env.addresses[1])).to.be.revertedWith(
+                `AccessControl: account ${env.addresses[1].toLowerCase()} is missing role ${defaultAdminRole}`
+            );
+            await expect(env.fuelERC20Gateway.connect(env.signers[1]).upgradeTo(env.addresses[1])).to.be.revertedWith(
+                'Ownable: caller is not the owner'
+            );
+        });
+    });
 });


### PR DESCRIPTION
There are a couple of nitpicks with the code to address:

- rename L1ERC20Gateway to FuelERC20Gateway to be more consistent with the naming of other contracts
- rename sendETH to depositETH to better reflect the deposit/withdraw nomenclature when messages only deal with amounts and no data
- stop using the s_ prefix on our storage variables and instead match the standard found in openzeppelins contracts
- stop the formatter from using tabs for js/ts